### PR TITLE
Use Fetcher trait for OCSP fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
 name = "fastly_compute"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64",
  "fastly",
  "futures 0.3.14",

--- a/cloudflare_worker/Cargo.toml
+++ b/cloudflare_worker/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.7.2"
 pem = "0.8.3"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_yaml = "0.8.17"
-sxg_rs = { path = "../sxg_rs", features = ["js_signer"] }
+sxg_rs = { path = "../sxg_rs", features = ["js_fetcher", "js_signer"] }
 wasm-bindgen = { version = "0.2.73", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.23"
 

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -36,10 +36,11 @@ pub fn get_last_error_message() -> JsValue {
     utils::get_last_error_message()
 }
 
-#[wasm_bindgen(js_name=createOcspRequest)]
-pub fn create_ocsp_request() -> Uint8Array {
-    let request = WORKER.create_ocsp_request();
-    Uint8Array::from(request)
+#[wasm_bindgen(js_name=fetchOcspFromDigicert)]
+pub async fn fetch_ocsp_from_digicert(fetcher: Function) -> Uint8Array {
+    let fetcher = Box::new(sxg_rs::fetcher::js_fetcher::JsFetcher::new(fetcher));
+    let request = WORKER.fetch_ocsp_from_digicert(fetcher).await;
+    Uint8Array::from(request.as_slice())
 }
 
 #[wasm_bindgen(js_name=servePresetContent)]

--- a/cloudflare_worker/worker/src/wasmFunctions.ts
+++ b/cloudflare_worker/worker/src/wasmFunctions.ts
@@ -20,7 +20,7 @@ declare var wasm_bindgen: any;
 type HeaderFields = Array<[string, string]>;
 
 export interface WasmRequest {
-  body: Uint8Array,
+  body: number[],
   headers: HeaderFields,
   method: 'Get' | 'Post',
   url: string,

--- a/cloudflare_worker/worker/src/wasmFunctions.ts
+++ b/cloudflare_worker/worker/src/wasmFunctions.ts
@@ -19,14 +19,20 @@ declare var wasm_bindgen: any;
 
 type HeaderFields = Array<[string, string]>;
 
+export interface WasmRequest {
+  body: Uint8Array,
+  headers: HeaderFields,
+  method: 'Get' | 'Post',
+  url: string,
+}
+
 export interface WasmResponse {
-  body: Uint8Array;
+  body: number[];
   headers: HeaderFields;
   status: number;
 }
 
 interface WasmFunctions {
-  createOcspRequest(): Uint8Array;
   createRequestHeaders(fields: HeaderFields): HeaderFields;
   createSignedExchange(
     fallbackUrl: string,
@@ -36,6 +42,7 @@ interface WasmFunctions {
     nowInSeconds: number,
     signer: (input: Uint8Array) => Promise<Uint8Array>,
   ): WasmResponse,
+  fetchOcspFromDigicert(fetcher: (request: WasmRequest) => Promise<WasmResponse>): Uint8Array,
   getLastErrorMessage(): string;
   servePresetContent(url: string, ocsp: Uint8Array): WasmResponse;
   shouldRespondDebugInfo(): boolean;

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -23,6 +23,7 @@ publish = false
 debug = false
 
 [dependencies]
+async-trait = "0.1.50"
 base64 = "0.13.0"
 fastly = "^0.7.3"
 futures = { version = "0.3.14", features = ["executor"] }

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -33,7 +33,7 @@ pub struct FastlyFetcher {
 }
 
 impl FastlyFetcher {
-    /// Construct a new `FastlyFetcher` from the backend name.
+    /// Constructs a new `FastlyFetcher` from the backend name.
     /// This function does not create the backend in Fastly;
     /// the Fastly backend need to be created via Fastly API
     /// before calling this function.

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -1,0 +1,88 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use fastly::{
+    Request as FastlyRequest,
+    Response as FastlyResponse,
+};
+use sxg_rs::http::{
+    HttpRequest,
+    HttpResponse,
+    Method,
+};
+
+pub struct FastlyFetcher {
+    backend_name: &'static str,
+}
+
+impl FastlyFetcher {
+    pub fn new(backend_name: &'static str) -> Self {
+        FastlyFetcher {
+            backend_name: backend_name,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl sxg_rs::fetcher::Fetcher for FastlyFetcher {
+    async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse, String> {
+        let request = from_http_request(request);
+        let response: FastlyResponse = request.send(self.backend_name).map_err(|err| {
+            format!(r#"Fetching leads to error "{}""#, err)
+        })?;
+        into_http_response(response)
+    }
+}
+
+fn from_http_request(http_request: HttpRequest) -> FastlyRequest {
+    let method = match http_request.method {
+        Method::Get => "GET",
+        Method::Post => "POST",
+    };
+    let mut fastly_request = FastlyRequest::new(method, http_request.url);
+    for (name, value) in http_request.headers {
+        fastly_request.append_header(name, value)
+    }
+    fastly_request.set_body(http_request.body);
+    fastly_request
+}
+
+pub fn from_http_response(input: HttpResponse) -> FastlyResponse {
+    let mut output = FastlyResponse::new();
+    output.set_status(input.status);
+    for (name, value) in input.headers {
+        output.append_header(name, value)
+    }
+    output.set_body(input.body);
+    output
+}
+
+fn into_http_response(response: FastlyResponse) -> Result<HttpResponse, String> {
+    let mut header_fields = vec![];
+    for name in response.get_header_names() {
+        for value in response.get_header_all(name) {
+            let value = value.to_str().map_err(|_| {
+                format!(r#"Header "{}" contains non-ASCII value."#, name)
+            })?;
+            header_fields.push((name.as_str().to_string(), value.to_string()));
+        }
+    }
+    let status = response.get_status().as_u16();
+    Ok(HttpResponse {
+        body: response.into_body_bytes(),
+        headers: header_fields,
+        status,
+    })
+}

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -17,12 +17,17 @@ use fastly::{
     Request as FastlyRequest,
     Response as FastlyResponse,
 };
-use sxg_rs::http::{
-    HttpRequest,
-    HttpResponse,
-    Method,
+use sxg_rs::{
+    fetcher::Fetcher,
+    http::{
+        HttpRequest,
+        HttpResponse,
+        Method,
+    },
 };
 
+/// A [`Fetcher`] implemented by
+/// [Fastly backend](https://developer.fastly.com/reference/api/services/backend/).
 pub struct FastlyFetcher {
     backend_name: &'static str,
 }
@@ -36,7 +41,7 @@ impl FastlyFetcher {
 }
 
 #[async_trait(?Send)]
-impl sxg_rs::fetcher::Fetcher for FastlyFetcher {
+impl Fetcher for FastlyFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse, String> {
         let request = from_http_request(request);
         let response: FastlyResponse = request.send(self.backend_name).map_err(|err| {

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -33,6 +33,10 @@ pub struct FastlyFetcher {
 }
 
 impl FastlyFetcher {
+    /// Construct a new `FastlyFetcher` from the backend name.
+    /// This function does not create the backend in Fastly;
+    /// the Fastly backend need to be created via Fastly API
+    /// before calling this function.
     pub fn new(backend_name: &'static str) -> Self {
         FastlyFetcher {
             backend_name: backend_name,

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+js_fetcher = []
 js_signer = []
 rust_signer = []
 

--- a/sxg_rs/src/config.rs
+++ b/sxg_rs/src/config.rs
@@ -41,7 +41,6 @@ pub struct Config {
     pub cert_der: Vec<u8>,
     pub cert_url: String,
     pub issuer_der: Vec<u8>,
-    pub ocsp_request: Vec<u8>,
     pub validity_url: String,
 }
 
@@ -58,7 +57,6 @@ impl Config {
         let input: ConfigInput = serde_yaml::from_str(input_yaml).unwrap();
         let cert_der = get_der(cert_pem, "CERTIFICATE");
         let issuer_der = get_der(issuer_pem, "CERTIFICATE");
-        let ocsp_request = crate::ocsp::create_ocsp_request(&cert_der, &issuer_der);
         let cert_url = create_url(&input.worker_host, &input.reserved_path, &input.cert_url_basename);
         let validity_url = create_url(&input.html_host, &input.reserved_path, &input.validity_url_basename);
         Config {
@@ -66,7 +64,6 @@ impl Config {
             cert_url,
             input,
             issuer_der,
-            ocsp_request,
             validity_url,
         }
     }
@@ -99,4 +96,3 @@ mod tests {
         assert_eq!(create_url("foo.com", "/.sxg/", "/cert"), "https://foo.com/.sxg/cert");
     }
 }
-

--- a/sxg_rs/src/fetcher/js_fetcher.rs
+++ b/sxg_rs/src/fetcher/js_fetcher.rs
@@ -17,9 +17,19 @@ use wasm_bindgen::JsValue;
 use crate::http::{HttpRequest, HttpResponse};
 use super::Fetcher;
 
+/// A [`Fetcher`] implemented by JavaScript.
 pub struct JsFetcher(JsFunction);
 
 impl JsFetcher {
+    /// Construct a new `JsFetcher` with a given JavaScript function,
+    /// which takes a [`HttpRequest`] and returns a
+    /// [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+    /// of [`HttpResponse`].
+    /// ```typescript
+    /// function js_function(req: HttpRequest): Promise<HttpResponse> {...}
+    /// ```
+    /// # Panics
+    /// Panics if `js_function` throws an error.
     pub fn new(js_function: JsFunction) -> Self {
         JsFetcher(js_function)
     }

--- a/sxg_rs/src/fetcher/js_fetcher.rs
+++ b/sxg_rs/src/fetcher/js_fetcher.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use async_trait::async_trait;
 use js_sys::Function as JsFunction;
 use wasm_bindgen::JsValue;

--- a/sxg_rs/src/fetcher/js_fetcher.rs
+++ b/sxg_rs/src/fetcher/js_fetcher.rs
@@ -21,7 +21,7 @@ use super::Fetcher;
 pub struct JsFetcher(JsFunction);
 
 impl JsFetcher {
-    /// Construct a new `JsFetcher` with a given JavaScript function,
+    /// Constructs a new `JsFetcher` with a given JavaScript function,
     /// which takes a [`HttpRequest`] and returns a
     /// [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
     /// of [`HttpResponse`].

--- a/sxg_rs/src/fetcher/js_fetcher.rs
+++ b/sxg_rs/src/fetcher/js_fetcher.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use async_trait::async_trait;
+use js_sys::Function as JsFunction;
+use wasm_bindgen::JsValue;
+use crate::http::{HttpRequest, HttpResponse};
+use super::Fetcher;
+
+pub struct JsFetcher(JsFunction);
+
+impl JsFetcher {
+    pub fn new(js_function: JsFunction) -> Self {
+        JsFetcher(js_function)
+    }
+}
+
+#[async_trait(?Send)]
+impl Fetcher for JsFetcher {
+    async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse, String> {
+        let request = JsValue::from_serde(&request).unwrap();
+        let this = JsValue::null();
+        let response = self.0.call1(&this, &request).unwrap();
+        let response = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(response));
+        let response = response.await.unwrap();
+        let response: HttpResponse = response.into_serde().unwrap();
+        Ok(response)
+    }
+}

--- a/sxg_rs/src/fetcher/mod.rs
+++ b/sxg_rs/src/fetcher/mod.rs
@@ -4,8 +4,8 @@ pub mod js_fetcher;
 use async_trait::async_trait;
 use crate::http::{HttpRequest, HttpResponse};
 
+/// An interface for fetching resources from network.
 #[async_trait(?Send)]
 pub trait Fetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse, String>;
 }
-

--- a/sxg_rs/src/fetcher/mod.rs
+++ b/sxg_rs/src/fetcher/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(feature="js_fetcher")]
 pub mod js_fetcher;
 

--- a/sxg_rs/src/fetcher/mod.rs
+++ b/sxg_rs/src/fetcher/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(feature="js_fetcher")]
+pub mod js_fetcher;
+
+use async_trait::async_trait;
+use crate::http::{HttpRequest, HttpResponse};
+
+#[async_trait(?Send)]
+pub trait Fetcher {
+    async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse, String>;
+}
+

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -14,14 +14,13 @@
 
 use std::collections::{HashMap, HashSet};
 use once_cell::sync::Lazy;
+use crate::http::HeaderFields;
 
 #[derive(Debug)]
 pub struct Headers(HashMap<String, String>);
 
-pub type Fields = Vec<(String, String)>;
-
 impl Headers {
-    pub fn new(data: Fields) -> Self {
+    pub fn new(data: HeaderFields) -> Self {
         let mut headers = Headers(HashMap::new());
         for (mut k, v) in data.into_iter() {
             k.make_ascii_lowercase();
@@ -29,7 +28,7 @@ impl Headers {
         }
         headers
     }
-    pub fn forward_to_origin_server(self, forwarded_header_names: &HashSet<String>) -> Result<Fields, String> {
+    pub fn forward_to_origin_server(self, forwarded_header_names: &HashSet<String>) -> Result<HeaderFields, String> {
         let accept = self.0.get("accept").ok_or("The request does not have accept header")?;
         validate_sxg_request_header(accept)?;
         // Set Via per https://tools.ietf.org/html/rfc7230#section-5.7.1

--- a/sxg_rs/src/http.rs
+++ b/sxg_rs/src/http.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct HttpRequest {
+    pub body: Vec<u8>,
+    pub headers: HeaderFields,
+    pub method: Method,
+    pub url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct HttpResponse {
+    pub body: Vec<u8>,
+    pub headers: HeaderFields,
+    pub status: u16,
+}
+
+pub type HeaderFields = Vec<(String, String)>;
+
+#[derive(Serialize)]
+pub enum Method {
+    Get,
+    Post,
+}
+


### PR DESCRIPTION
`sxg_rs` now accepts a dynamic `Fetcher` object, and use it to fetch OCSP from the issuer.