### PR TITLE
Create an entrypoint to test a deployed worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures 0.4.23",
  "x509-parser",

--- a/cloudflare_worker/README.md
+++ b/cloudflare_worker/README.md
@@ -62,6 +62,9 @@ limitations under the License.
 
 1. Run `./publish.sh` to build and deploy the worker online.
 
+1. To check whether the worker generates a valid SXG,
+   use Chrome browser to open `https://${WORKER_HOST}/.sxg/test.html`.
+
 1. The Google SXG Cache tries to [update SXGs
    often](https://developers.google.com/search/docs/advanced/experience/signed-exchange#:~:text=Regardless%20of%20the,the%20SXG%20response.),
    but may reuse them for up to 7 days. To ensure they expire sooner, use

--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -163,12 +163,12 @@ async function handleRequest(request: Request) {
     let sxgPayload: Response;
     const presetContent = servePresetContent(request.url, ocsp);
     if (presetContent) {
-      if ('direct' in presetContent) {
-        return responseFromWasm(presetContent.direct);
+      if (presetContent.kind === 'direct') {
+        return responseFromWasm(presetContent);
       } else {
-        fallbackUrl = presetContent.toBeSigned.url;
-        fallback = responseFromWasm(presetContent.toBeSigned.fallback);
-        sxgPayload = responseFromWasm(presetContent.toBeSigned.payload);
+        fallbackUrl = presetContent.url;
+        fallback = responseFromWasm(presetContent.fallback);
+        sxgPayload = responseFromWasm(presetContent.payload);
         // Although we are not sending any request to HTML_HOST,
         // we still need to check the validity of the request header.
         // For example, if the header does not contain

--- a/cloudflare_worker/worker/src/wasmFunctions.ts
+++ b/cloudflare_worker/worker/src/wasmFunctions.ts
@@ -32,14 +32,11 @@ export interface WasmResponse {
   status: number;
 }
 
-export type PresetContent = {
-  direct: WasmResponse,
-} | {
-  toBeSigned: {
-    url: string,
-    payload: WasmResponse,
-    fallback: WasmResponse,
-  }
+export type PresetContent = ({ kind: 'direct' } & WasmResponse) | {
+  kind: 'toBeSigned',
+  url: string,
+  payload: WasmResponse,
+  fallback: WasmResponse,
 }
 
 interface WasmFunctions {

--- a/cloudflare_worker/worker/src/wasmFunctions.ts
+++ b/cloudflare_worker/worker/src/wasmFunctions.ts
@@ -32,6 +32,16 @@ export interface WasmResponse {
   status: number;
 }
 
+export type PresetContent = {
+  direct: WasmResponse,
+} | {
+  toBeSigned: {
+    url: string,
+    payload: WasmResponse,
+    fallback: WasmResponse,
+  }
+}
+
 interface WasmFunctions {
   createRequestHeaders(fields: HeaderFields): HeaderFields;
   createSignedExchange(
@@ -44,7 +54,7 @@ interface WasmFunctions {
   ): WasmResponse,
   fetchOcspFromDigicert(fetcher: (request: WasmRequest) => Promise<WasmResponse>): Uint8Array,
   getLastErrorMessage(): string;
-  servePresetContent(url: string, ocsp: Uint8Array): WasmResponse;
+  servePresetContent(url: string, ocsp: Uint8Array): PresetContent | undefined;
   shouldRespondDebugInfo(): boolean;
   validatePayloadHeaders(fields: HeaderFields): void,
 }

--- a/fastly_compute/README.md
+++ b/fastly_compute/README.md
@@ -63,6 +63,9 @@ limitations under the License.
 
 1. Run `fastly compute publish`.
 
+1. To check whether the worker generates a valid SXG,
+   use Chrome browser to open `https://${WORKER_HOST}/.sxg/test.html`.
+
 1. The Google SXG Cache tries to [update SXGs
    often](https://developers.google.com/search/docs/advanced/experience/signed-exchange#:~:text=Regardless%20of%20the,the%20SXG%20response.),
    but may reuse them for up to 7 days. To ensure they expire sooner, [control

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -37,6 +37,7 @@ pem = "0.8.3"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_yaml = "0.8.17"
 sha2 = "0.9.3"
+url = "2.2.2"
 wasm-bindgen = { version = "0.2.73", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.23"
 x509-parser = "0.9.2"

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -35,7 +35,7 @@ pub struct SxgWorker {
 }
 
 #[derive(Serialize)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all="camelCase", tag="kind")]
 pub enum PresetContent {
     Direct(HttpResponse),
     ToBeSigned {

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -28,9 +28,21 @@ mod utils;
 use config::Config;
 use headers::Headers;
 use http::{HeaderFields, HttpResponse};
+use serde::Serialize;
 
 pub struct SxgWorker {
     pub config: Config,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all="camelCase")]
+pub enum PresetContent {
+    Direct(HttpResponse),
+    ToBeSigned {
+        url: String,
+        payload: HttpResponse,
+        fallback: HttpResponse,
+    }
 }
 
 impl SxgWorker {
@@ -99,21 +111,67 @@ impl SxgWorker {
     pub async fn fetch_ocsp_from_digicert(&self, fetcher: Box<dyn fetcher::Fetcher>) -> Vec<u8> {
         ocsp::fetch_from_digicert(&self.config.cert_der, &self.config.issuer_der, fetcher).await
     }
-    pub fn serve_preset_content(&self, req_url: &str, ocsp_der: &[u8]) -> Option<HttpResponse> {
-        if req_url == self.config.cert_url {
-            Some(HttpResponse {
+    pub fn serve_preset_content(&self, req_url: &str, ocsp_der: &[u8]) -> Option<PresetContent> {
+        let req_url = url::Url::parse(req_url).ok()?;
+        let path: Vec<_> = req_url.path_segments()?.collect();
+        let basename = if path.len() == 2 && path[0] == self.config.reserved_path.trim_matches('/') {
+            path[1]
+        } else {
+            return None;
+        };
+        if basename == self.config.cert_url_basename {
+            Some(PresetContent::Direct(HttpResponse {
                 body: self.create_cert_cbor(ocsp_der),
                 headers: vec![(String::from("content-type"), String::from("application/cert-chain+cbor"))],
                 status: 200,
-            })
-        } else if req_url == self.config.validity_url {
-            Some(HttpResponse {
+            }))
+        } else if basename == self.config.validity_url_basename {
+            Some(PresetContent::Direct(HttpResponse {
                 body: self.create_validity(),
                 headers: vec![(String::from("content-type"), String::from("application/cbor"))],
                 status: 200,
+            }))
+        } else if basename == "test.html" {
+            Some(PresetContent::Direct(HttpResponse {
+                headers: vec![(String::from("content-type"), String::from("text/html"))],
+                status: 200,
+                body: include_bytes!("static/entrypoint.html").to_vec(),
+            }))
+        } else if basename == "prefetch.html" {
+            Some(PresetContent::Direct(HttpResponse {
+                headers: vec![(String::from("content-type"), String::from("text/html"))],
+                status: 200,
+                body: include_bytes!("static/prefetch.html").to_vec(),
+            }))
+        } else if basename == "fallback.html" {
+            Some(PresetContent::Direct(HttpResponse {
+                headers: vec![(String::from("content-type"), String::from("text/html"))],
+                status: 200,
+                body: include_bytes!("./static/fallback.html").to_vec(),
+            }))
+        } else if basename == "success.sxg" {
+            let mut fallback_url = req_url;
+            fallback_url.set_host(Some(&self.config.html_host)).ok()?;
+            fallback_url.set_path(&fallback_url.path().replace("success.sxg", "fallback.html"));
+            Some(PresetContent::ToBeSigned {
+                url: fallback_url.to_string(),
+                payload: HttpResponse {
+                    headers: vec![(String::from("content-type"), String::from("text/html"))],
+                    status: 200,
+                    body: include_bytes!("./static/success.html").to_vec(),
+                },
+                fallback: HttpResponse {
+                    headers: vec![(String::from("content-type"), String::from("text/html"))],
+                    status: 200,
+                    body: include_bytes!("./static/fallback.html").to_vec(),
+                },
             })
         } else {
-            None
+            Some(PresetContent::Direct(HttpResponse {
+                headers: vec![(String::from("content-type"), String::from("text/plain"))],
+                status: 404,
+                body: format!("Unknown path {}", req_url).into_bytes(),
+            }))
         }
     }
     pub fn transform_request_headers(&self, fields: HeaderFields) -> Result<HeaderFields, String> {

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -135,13 +135,13 @@ impl SxgWorker {
             Some(PresetContent::Direct(HttpResponse {
                 headers: vec![(String::from("content-type"), String::from("text/html"))],
                 status: 200,
-                body: include_bytes!("static/entrypoint.html").to_vec(),
+                body: include_bytes!("./static/test.html").to_vec(),
             }))
         } else if basename == "prefetch.html" {
             Some(PresetContent::Direct(HttpResponse {
                 headers: vec![(String::from("content-type"), String::from("text/html"))],
                 status: 200,
-                body: include_bytes!("static/prefetch.html").to_vec(),
+                body: include_bytes!("./static/prefetch.html").to_vec(),
             }))
         } else if basename == "fallback.html" {
             Some(PresetContent::Direct(HttpResponse {
@@ -149,10 +149,10 @@ impl SxgWorker {
                 status: 200,
                 body: include_bytes!("./static/fallback.html").to_vec(),
             }))
-        } else if basename == "success.sxg" {
+        } else if basename == "test.sxg" {
             let mut fallback_url = req_url;
             fallback_url.set_host(Some(&self.config.html_host)).ok()?;
-            fallback_url.set_path(&fallback_url.path().replace("success.sxg", "fallback.html"));
+            fallback_url.set_path(&fallback_url.path().replace("test.sxg", "fallback.html"));
             Some(PresetContent::ToBeSigned {
                 url: fallback_url.to_string(),
                 payload: HttpResponse {

--- a/sxg_rs/src/static/entrypoint.html
+++ b/sxg_rs/src/static/entrypoint.html
@@ -1,0 +1,18 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<iframe src="./prefetch.html"></iframe>

--- a/sxg_rs/src/static/fallback.html
+++ b/sxg_rs/src/static/fallback.html
@@ -1,0 +1,18 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>No, the SXG fails.</p>

--- a/sxg_rs/src/static/prefetch.html
+++ b/sxg_rs/src/static/prefetch.html
@@ -13,15 +13,27 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<!--
+This `prefetch.html` fetches an SXG and navigates to it. After the navigation,
+the `window.location` will be changed to `fallback.html`.
+To reload this page, care must be taken to reload from `prefetch.html`,
+rather than from `fallback.html`.
+If the user clicks browser's `reload` button after the navigation, the browser
+will reload `fallback.html`, and it will result in a error.
+-->
 <!DOCTYPE html>
 <meta charset="utf-8">
 <p>Loading SXG test page in 2 seconds</p>
 <script>
-  const sxgUrl = `./success.sxg?q=${Math.random()}`;
+  const sxgUrl = `./test.sxg?q=${Math.random()}`;
   const link = document.createElement('link');
+  // This `prefetch` attribute triggers Chrome to prefer SXG content-type.
   link.setAttribute('rel', 'prefetch')
   link.setAttribute('href', sxgUrl);
   document.head.append(link);
+  // Wait a long time so that SXG is likely to have been fully loaded.
+  // However, if the Chrome network is throttled to `slow 3G`,
+  // 2000 milliseconds will be not enough, and fails to navigate.
   setTimeout(() => {
     window.location = sxgUrl;
   }, 2000);

--- a/sxg_rs/src/static/prefetch.html
+++ b/sxg_rs/src/static/prefetch.html
@@ -1,0 +1,28 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>Loading SXG test page in 2 seconds</p>
+<script>
+  const sxgUrl = `./success.sxg?q=${Math.random()}`;
+  const link = document.createElement('link');
+  link.setAttribute('rel', 'prefetch')
+  link.setAttribute('href', sxgUrl);
+  document.head.append(link);
+  setTimeout(() => {
+    window.location = sxgUrl;
+  }, 2000);
+</script>

--- a/sxg_rs/src/static/success.html
+++ b/sxg_rs/src/static/success.html
@@ -1,0 +1,18 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<p>Yes, this message comes from a valid SXG.</p>

--- a/sxg_rs/src/static/test.html
+++ b/sxg_rs/src/static/test.html
@@ -15,4 +15,8 @@ limitations under the License.
 -->
 <!DOCTYPE html>
 <meta charset="utf-8">
+<!--
+This ensures that hitting browser's "reload" button shows success again.
+More details are in the file-level comments of "prefetch.html".
+-->
 <iframe src="./prefetch.html"></iframe>


### PR DESCRIPTION
The worker serves `/.sxg/test.html` as the entrypoint to do an end-to-end test. The user can use their browser to see the validity of the SXG generated by the worker.

Other changes:
* The worker now uses the `url` crate to parse the `request.url`, rather than simply compare the string value.