### PR TITLE
Add config params for strip req/resp headers.

### DIFF
--- a/cloudflare_worker/config.example.yaml
+++ b/cloudflare_worker/config.example.yaml
@@ -18,7 +18,8 @@ forward_request_headers:
   - "cf-ipcountry"
   - "user-agent"
 html_host: my_domain.com
-reject_stateful_headers: false
+strip_request_headers: []
+strip_response_headers: ["set-cookie", "strict-transport-security"]
 reserved_path: ".sxg"
 respond_debug_info: false
 validity_url_basename: "validity"

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn create_signed_exchange(
     now_in_seconds: u32,
     signer: Function,
 ) -> Result<JsValue, JsValue> {
-    let payload_headers = ::sxg_rs::headers::Headers::new(payload_headers.into_serde().unwrap());
+    let payload_headers = ::sxg_rs::headers::Headers::new(payload_headers.into_serde().unwrap(), &WORKER.config.strip_response_headers);
     let signer = Box::new(::sxg_rs::signature::js_signer::JsSigner::new(signer));
     let sxg = WORKER.create_signed_exchange(::sxg_rs::CreateSignedExchangeParams {
         fallback_url: &fallback_url,

--- a/fastly_compute/config.example.yaml
+++ b/fastly_compute/config.example.yaml
@@ -19,7 +19,8 @@ forward_request_headers:
   - "user-agent"
 html_host: my_domain.com
 private_key_base64: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-reject_stateful_headers: true
+strip_request_headers: []
+strip_response_headers: ["set-cookie", "strict-transport-security"]
 reserved_path: ".sxg"
 respond_debug_info: true
 validity_url_basename: "validity"

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -59,7 +59,7 @@ fn get_req_header_fields(req: &Request) -> Result<Headers, String> {
             fields.push((name.as_str().to_string(), value.to_string()))
         }
     }
-    Ok(Headers::new(fields))
+    Ok(Headers::new(fields, &WORKER.config.strip_request_headers))
 }
 
 fn get_rsp_header_fields(rsp: &Response) -> Result<Headers, String> {
@@ -72,7 +72,7 @@ fn get_rsp_header_fields(rsp: &Response) -> Result<Headers, String> {
             fields.push((name.as_str().to_string(), value.to_string()))
         }
     }
-    Ok(Headers::new(fields))
+    Ok(Headers::new(fields, &WORKER.config.strip_response_headers))
 }
 
 fn fetch_from_html_server(url: &Url, req_headers: Vec<(String, String)>) -> Result<Response, String> {
@@ -89,7 +89,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
     let private_key_der = base64::decode(&WORKER.config.private_key_base64).unwrap();
     let signer = Box::new(::sxg_rs::signature::rust_signer::RustSigner::new(&private_key_der));
     let payload_headers = get_rsp_header_fields(&payload)?;
-    payload_headers.validate_as_sxg_payload(WORKER.config.reject_stateful_headers)?;
+    payload_headers.validate_as_sxg_payload()?;
     let payload_body = payload.into_body_bytes();
     let sxg = WORKER.create_signed_exchange(sxg_rs::CreateSignedExchangeParams {
         now: std::time::SystemTime::now(),

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -175,12 +175,12 @@ impl SxgWorker {
         }
     }
     pub fn transform_request_headers(&self, fields: HeaderFields) -> Result<HeaderFields, String> {
-        let headers = Headers::new(fields);
+        let headers = Headers::new(fields, &self.config.strip_request_headers);
         headers.forward_to_origin_server(&self.config.forward_request_headers)
     }
     pub fn validate_payload_headers(&self, fields: HeaderFields) -> Result<(), String> {
-        let headers = Headers::new(fields);
-        headers.validate_as_sxg_payload(self.config.reject_stateful_headers)
+        let headers = Headers::new(fields, &self.config.strip_response_headers);
+        headers.validate_as_sxg_payload()
     }
 }
 


### PR DESCRIPTION
Change the default behavior to strip set-cookie and strict-transport-security,
and reject on all other stateful headers.

- Remove the reject_stateful_headers boolean and make that behavior the default.
- Add strip_response_headers param with default value of those 2 headers.
- Add strip_request_headers param because it was easy to do and may be helpful.

Fixes #10.