### PR TITLE
Verify signature/headers length for SXG.

### DIFF
--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -16,6 +16,7 @@ mod utils;
 
 use js_sys::{Function, Uint8Array};
 use once_cell::sync::Lazy;
+use sxg_rs::http::HttpResponse;
 use wasm_bindgen::prelude::*;
 
 pub static WORKER: Lazy<::sxg_rs::SxgWorker> = Lazy::new(|| {
@@ -90,14 +91,14 @@ pub async fn create_signed_exchange(
 ) -> Result<JsValue, JsValue> {
     let payload_headers = ::sxg_rs::headers::Headers::new(payload_headers.into_serde().unwrap());
     let signer = Box::new(::sxg_rs::signature::js_signer::JsSigner::new(signer));
-    let sxg = WORKER.create_signed_exchange(::sxg_rs::CreateSignedExchangeParams {
+    let sxg: HttpResponse = WORKER.create_signed_exchange(::sxg_rs::CreateSignedExchangeParams {
         fallback_url: &fallback_url,
         now: std::time::UNIX_EPOCH + std::time::Duration::from_secs(now_in_seconds as u64),
         payload_body: &payload_body,
         payload_headers,
         signer,
         status_code,
-    }).await;
+    }).await.map_err(|err| JsValue::from_str(&err))?;
     Ok(JsValue::from_serde(&sxg).unwrap())
 }
 

--- a/fastly_compute/README.md
+++ b/fastly_compute/README.md
@@ -19,7 +19,8 @@ limitations under the License.
 1. Get an SXG-compatible certificate
    using [these steps](../credentials/README.md#get-an-sxg_compatible-certificate).
 
-1. Install [Rust](https://www.rust-lang.org/tools/install).
+1. Install [Rust](https://www.rust-lang.org/tools/install) using
+   [rustup](https://rustup.rs/)
 
 1. Install [Fastly CLI](https://github.com/fastly/cli).
 

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -99,7 +99,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
         status_code: 200,
         fallback_url: fallback_url.as_str(),
     });
-    let sxg = block_on(sxg);
+    let sxg = block_on(sxg)?;
     Ok(fetcher::from_http_response(sxg))
 }
 

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -69,7 +69,7 @@ impl SxgWorker {
         ]);
         cert_cbor.serialize()
     }
-    pub async fn create_signed_exchange<'a>(&self, params: CreateSignedExchangeParams<'a>) -> HttpResponse {
+    pub async fn create_signed_exchange<'a>(&self, params: CreateSignedExchangeParams<'a>) -> Result<HttpResponse, String> {
         let CreateSignedExchangeParams {
             fallback_url,
             now,
@@ -94,15 +94,15 @@ impl SxgWorker {
             signer,
             validity_url: &self.config.validity_url,
         }).await;
-        let sxg_body = sxg::build(fallback_url, &signature.serialize(), &signed_headers, &payload_body);
-        HttpResponse {
+        let sxg_body = sxg::build(fallback_url, &signature.serialize(), &signed_headers, &payload_body)?;
+        Ok(HttpResponse {
             body: sxg_body,
             headers: vec![
                 (String::from("content-type"), String::from("application/signed-exchange;v=b3")),
                 (String::from("x-content-type-options"), String::from("nosniff")),
             ],
             status: 200,
-        }
+        })
     }
     pub fn create_validity(&self) -> Vec<u8> {
         let validity = cbor::DataItem::Map(vec![]);

--- a/sxg_rs/src/sxg.rs
+++ b/sxg_rs/src/sxg.rs
@@ -13,8 +13,15 @@
 // limitations under the License.
 
 // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#application-signed-exchange
-pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payload_body: &[u8]) -> Vec<u8> {
-    [
+pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payload_body: &[u8]) -> Result<Vec<u8>, String> {
+    // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#name-application-signed-exchange
+    if signature.len() > 16384 {
+        return Err("sigLength is larger than 16384".into())
+    }
+    if signed_headers.len() > 524288 {
+        return Err("headerLength is larger than 524288".into())
+    }
+    Ok([
         "sxg1-b3\0".as_bytes(),
         &(fallback_url.len() as u16).to_be_bytes(),
         fallback_url.as_bytes(),
@@ -23,6 +30,6 @@ pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payloa
         signature,
         signed_headers,
         payload_body,
-    ].concat()
+    ].concat())
 }
 


### PR DESCRIPTION
This is to avoid constructing an SXG that will result in an unrecoverable parse
error.

Fixes #12.