### PR TITLE
Determine SXG duration based on cache-control.

### DIFF
--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -354,10 +354,12 @@ mod tests {
         assert_eq!(headers(vec![("cache-control", "max-age=100")]).signature_duration().unwrap_err(), "Validity duration is too short.");
         assert_eq!(headers(vec![("cache-control", "max-age=100, s-maxage=3600")]).signature_duration().unwrap(), Duration::from_secs(3600));
         assert_eq!(headers(vec![("cache-control", "max-age=3600, s-maxage=100")]).signature_duration().unwrap_err(), "Validity duration is too short.");
+        assert_eq!(headers(vec![("cache-control", "max, max-age=3600")]).signature_duration().unwrap(), Duration::from_secs(3600));
     }
     #[test]
     fn signature_duration_parse_error() {
         assert_eq!(headers(vec![("cache-control", "max-age=fish")]).signature_duration().unwrap(), SEVEN_DAYS);
         assert_eq!(headers(vec![("cache-control", "doesn't even parse")]).signature_duration().unwrap(), SEVEN_DAYS);
+        assert_eq!(headers(vec![("cache-control", "max=, max-age=3600")]).signature_duration().unwrap(), SEVEN_DAYS);
     }
 }

--- a/sxg_rs/src/http_parser/base.rs
+++ b/sxg_rs/src/http_parser/base.rs
@@ -114,6 +114,14 @@ fn char_if(predicate: fn (c: char) -> bool) -> impl Fn(&str) -> IResult<&str, ch
     }
 }
 
+named!(
+    pub parameter_value(&str) -> String,
+    alt!(
+        token => {|s: &str| s.to_string()} |
+        quoted_string => {|s| s}
+    )
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sxg_rs/src/http_parser/cache_control.rs
+++ b/sxg_rs/src/http_parser/cache_control.rs
@@ -1,0 +1,123 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nom::{
+    IResult,
+    branch::alt,
+    bytes::complete::tag_no_case,
+    character::complete::char,
+    combinator::map,
+    combinator::map_res,
+    combinator::opt,
+    sequence::pair,
+    sequence::preceded,
+};
+use std::time::Duration;
+use super::base::{
+    parameter_value,
+    token,
+};
+
+// https://datatracker.ietf.org/doc/html/rfc7234#section-5.2
+#[derive(Clone, Debug, PartialEq)]
+pub enum Directive {
+    SMaxAge(Duration),
+    MaxAge(Duration),
+    // Not relevant to the freshness lifetime computation.
+    Other,
+}
+
+pub fn directive(input: &str) -> IResult<&str, Directive> {
+    alt((
+        // Nonnegative integers up to 31 bits must be parseable per
+        // https://datatracker.ietf.org/doc/html/rfc7234#section-1.2.1.
+        // Parsers may allow higher numbers.
+        preceded(tag_no_case("s-maxage="),
+                 map(map_res(parameter_value, |s| s.parse::<u32>()),
+                     |i| Directive::SMaxAge(Duration::from_secs(i.into())))),
+        preceded(tag_no_case("max-age="),
+                 map(map_res(parameter_value, |s| s.parse::<u32>()),
+                     |i| Directive::MaxAge(Duration::from_secs(i.into())))),
+        map(pair(token, opt(pair(char('='), parameter_value))), |_| Directive::Other),
+    ))(input)
+}
+
+// Returns the freshness lifetime for use in a shared cache, as defined by
+// https://datatracker.ietf.org/doc/html/rfc7234#section-4.2.1, excluding
+// handling of the Expires header. The caller must already have validated the
+// response may be stored in the cache per
+// https://datatracker.ietf.org/doc/html/rfc7234#section-3. 'None' means the
+// lifetime is implicit.
+pub fn freshness_lifetime(directives: Vec<Directive>) -> Option<Duration> {
+    // RFC7234 does not specify what to do if multiple directives of the same
+    // name are present, but it appears that Chromium takes the first:
+    // https://source.chromium.org/chromium/chromium/src/+/main:net/http/http_response_headers.cc;l=799;drc=0ce9df69ba9e32bafc53c3d90db8a707c243da40
+    let mut s_maxage = None::<Duration>;
+    let mut max_age = None::<Duration>;
+    for directive in directives {
+        match directive {
+            Directive::SMaxAge(duration) => { s_maxage.get_or_insert(duration); },
+            Directive::MaxAge(duration) => { max_age.get_or_insert(duration); },
+            Directive::Other => (),
+        };
+    }
+    if let Some(duration) = s_maxage {
+        Some(duration)
+    } else if let Some(duration) = max_age {
+        Some(duration)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn directive_s_maxage() {
+        assert_eq!(directive("s-maxage=3600").unwrap(), ("", Directive::SMaxAge(Duration::from_secs(3600))));
+        assert_eq!(directive("s-maxage=\"3600\"").unwrap(), ("", Directive::SMaxAge(Duration::from_secs(3600))));
+        assert_eq!(directive("s-maxage=-1").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("s-maxage=1e6").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("s-maxage=\"3600").unwrap_err().to_string(), "Parsing requires more data");
+    }
+    #[test]
+    fn directive_max_age() {
+        assert_eq!(directive("max-age=3600").unwrap(), ("", Directive::MaxAge(Duration::from_secs(3600))));
+        assert_eq!(directive("max-age=\"3600\"").unwrap(), ("", Directive::MaxAge(Duration::from_secs(3600))));
+        assert_eq!(directive("max-age=-1").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("max-age=1e6").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("max-age=\"3600").unwrap_err().to_string(), "Parsing requires more data");
+    }
+    #[test]
+    fn directive_other() {
+        assert_eq!(directive("no-store").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("no-cache=set-cookie").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("no-cache=\"set-cookie, set-cookie2\"").unwrap(), ("", Directive::Other));
+        assert_eq!(directive("no-cache=\"set-cookie").unwrap_err().to_string(), "Parsing requires more data");
+    }
+    #[test]
+    fn directive_multiple() {
+        assert_eq!(directive("no-cache=\"set-cookie, set-cookie2\", no-store").unwrap(), (", no-store", Directive::Other));
+    }
+    #[test]
+    fn freshness_lifetimes() {
+        assert_eq!(freshness_lifetime(vec![]), None);
+        assert_eq!(freshness_lifetime(vec![Directive::SMaxAge(Duration::from_secs(3600))]), Some(Duration::from_secs(3600)));
+        assert_eq!(freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(3600))]), Some(Duration::from_secs(3600)));
+        assert_eq!(freshness_lifetime(vec![Directive::SMaxAge(Duration::from_secs(3600)), Directive::MaxAge(Duration::from_secs(200))]), Some(Duration::from_secs(3600)));
+        assert_eq!(freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(200)), Directive::SMaxAge(Duration::from_secs(3600))]), Some(Duration::from_secs(3600)));
+        assert_eq!(freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(3600)), Directive::MaxAge(Duration::from_secs(200))]), Some(Duration::from_secs(3600)));
+    }
+}

--- a/sxg_rs/src/http_parser/cache_control.rs
+++ b/sxg_rs/src/http_parser/cache_control.rs
@@ -72,13 +72,7 @@ pub fn freshness_lifetime(directives: Vec<Directive>) -> Option<Duration> {
             Directive::Other => (),
         };
     }
-    if let Some(duration) = s_maxage {
-        Some(duration)
-    } else if let Some(duration) = max_age {
-        Some(duration)
-    } else {
-        None
-    }
+    s_maxage.or(max_age)
 }
 
 #[cfg(test)]

--- a/sxg_rs/src/http_parser/media_type.rs
+++ b/sxg_rs/src/http_parser/media_type.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use nom::{
-    alt,
     character::complete::char as char1,
     many0,
     map,
@@ -24,7 +23,7 @@ use nom::{
 };
 use super::base::{
     ows,
-    quoted_string,
+    parameter_value,
     token,
 };
 
@@ -59,14 +58,6 @@ pub struct Parameter<'a> {
     pub name: &'a str,
     pub value: String,
 }
-
-named!(
-    parameter_value(&str) -> String,
-    alt!(
-        token => {|s: &str| s.to_string()} |
-        quoted_string => {|s| s}
-    )
-);
 
 // https://tools.ietf.org/html/rfc7231#section-3.1.1.1
 // `parameter` is defined as

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -14,6 +14,7 @@
 
 mod accept;
 mod base;
+mod cache_control;
 mod media_type;
 
 use nom::{
@@ -24,6 +25,7 @@ use nom::{
     separated_pair,
 };
 use base::ows;
+use std::time::Duration;
 
 fn format_nom_err(err: nom::Err<nom::error::Error<&str>>) -> String {
     format!("{}", err)
@@ -47,3 +49,8 @@ pub fn parse_accept_header(input: &str) -> Result<Vec<accept::Accept>, String> {
     parse_vec(input, accept::accept)
 }
 
+// Returns the freshness lifetime for a shared cache.
+pub fn parse_cache_control_header(input: &str) -> Result<Duration, String> {
+    let directives = parse_vec(input, cache_control::directive)?;
+    cache_control::freshness_lifetime(directives).ok_or("Freshness lifetime is implicit".into())
+}

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -82,12 +82,11 @@ impl SxgWorker {
         // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#section-3.5-7.9.1
         let (mice_digest, payload_body) = crate::mice::calculate(payload_body, 16384);
         let signed_headers = payload_headers.get_signed_headers_bytes(status_code, &mice_digest);
-        const SIX_DAYS: std::time::Duration = std::time::Duration::from_secs(60 * 60 * 24 * 6);
         let signature = signature::Signature::new(signature::SignatureParams {
             cert_url: &self.config.cert_url,
             cert_sha256: utils::get_sha(&self.config.cert_der),
             date: now,
-            expires: now + SIX_DAYS,
+            expires: now + payload_headers.signature_duration()?,
             headers: &signed_headers,
             id: "sig",
             request_url: fallback_url,


### PR DESCRIPTION
Default to 7 days, and lower the duration if the inner cache-control header has
an explicit s-maxage or max-age directive.

Fixes #15.