### PR TITLE
Serve SXG iff q-value == 1.

### DIFF
--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -17,6 +17,7 @@ mod utils;
 use js_sys::{Function, Uint8Array};
 use once_cell::sync::OnceCell;
 use sxg_rs::SxgWorker;
+use sxg_rs::headers::AcceptFilter;
 use sxg_rs::http::HttpResponse;
 use wasm_bindgen::prelude::*;
 
@@ -64,9 +65,10 @@ pub fn should_respond_debug_info() -> Result<bool, JsValue> {
 }
 
 #[wasm_bindgen(js_name=createRequestHeaders)]
-pub fn create_request_headers(requestor_headers: JsValue) -> Result<JsValue, JsValue> {
+pub fn create_request_headers(accept_filter: JsValue, requestor_headers: JsValue) -> Result<JsValue, JsValue> {
     let fields = requestor_headers.into_serde().unwrap();
-    let result = get_worker()?.transform_request_headers(fields);
+    let accept_filter: AcceptFilter = accept_filter.into_serde().unwrap();
+    let result = get_worker()?.transform_request_headers(fields, accept_filter);
     match result {
         Ok(fields) => {
             Ok(JsValue::from_serde(&fields).unwrap())
@@ -105,4 +107,3 @@ pub async fn create_signed_exchange(
     }).await.map_err(|err| JsValue::from_str(&err))?;
     Ok(JsValue::from_serde(&sxg).unwrap())
 }
-

--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -173,11 +173,11 @@ async function handleRequest(request: Request) {
         // we still need to check the validity of the request header.
         // For example, if the header does not contain
         // `Accept: signed-exchange;v=b3`, we will throw an error.
-        createRequestHeaders(Array.from(request.headers));
+        createRequestHeaders('AcceptsSxg', Array.from(request.headers));
       }
     } else {
       fallbackUrl = request.url;
-      const requestHeaders = createRequestHeaders(Array.from(request.headers));
+      const requestHeaders = createRequestHeaders('PrefersSxg', Array.from(request.headers));
       [sxgPayload, fallback] = teeResponse(await fetch(
         fallbackUrl,
         {

--- a/cloudflare_worker/worker/src/wasmFunctions.ts
+++ b/cloudflare_worker/worker/src/wasmFunctions.ts
@@ -19,6 +19,8 @@ declare var wasm_bindgen: any;
 
 type HeaderFields = Array<[string, string]>;
 
+export type AcceptFilter = 'PrefersSxg' | 'AcceptsSxg';
+
 export interface WasmRequest {
   body: number[],
   headers: HeaderFields,
@@ -40,7 +42,7 @@ export type PresetContent = ({ kind: 'direct' } & WasmResponse) | {
 }
 
 interface WasmFunctions {
-  createRequestHeaders(fields: HeaderFields): HeaderFields;
+  createRequestHeaders(accept_filter: AcceptFilter, fields: HeaderFields): HeaderFields;
   createSignedExchange(
     fallbackUrl: string,
     statusCode: number,

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -15,11 +15,23 @@
 use std::collections::{HashMap, HashSet};
 use once_cell::sync::Lazy;
 use crate::http::HeaderFields;
+use serde::Deserialize;
 use std::cmp::min;
 use std::time::Duration;
 
 #[derive(Debug)]
 pub struct Headers(HashMap<String, String>);
+
+// Which requestors to serve an SXG to.
+#[derive(Deserialize)]
+pub enum AcceptFilter {
+    // Those whose Accept header indicates they prefer an SXG over the unsigned
+    // version. That is, SXG caches and crawlers only.
+    PrefersSxg,
+    // Those whose Accept header indicates they accept an SXG, but generally
+    // prefer the unsigned version. That is, SXG-capable browsers plus the above.
+    AcceptsSxg,
+}
 
 // A default mobile user agent, for when the upstream request doesn't include one.
 const USER_AGENT: &str = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36";
@@ -38,7 +50,7 @@ impl Headers {
         }
         headers
     }
-    pub fn forward_to_origin_server(self, forwarded_header_names: &HashSet<String>) -> Result<HeaderFields, String> {
+    pub fn forward_to_origin_server(self, accept_filter: AcceptFilter, forwarded_header_names: &HashSet<String>) -> Result<HeaderFields, String> {
         if self.0.contains_key("authorization") {
             // We should not sign personalized content, but we cannot anonymize this request per
             // https://datatracker.ietf.org/doc/html/rfc7235#section-4.2:
@@ -46,7 +58,7 @@ impl Headers {
             return Err("The request contains an Authorization header.".to_string());
         }
         let accept = self.0.get("accept").ok_or("The request does not have an Accept header")?;
-        validate_accept_header(accept)?;
+        validate_accept_header(accept, accept_filter)?;
         // Set Via per https://tools.ietf.org/html/rfc7230#section-5.7.1
         let mut via = format!("sxgrs");
         if let Some(upstream_via) = self.0.get("via") {
@@ -213,9 +225,9 @@ static CACHE_CONTROL_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
 });
 
 // Checks whether to serve SXG based on the Accept header of the HTTP request.
-// Returns Ok iff the input string has a `application/signed-exchange;v=b3`
-// with a `q` value of 1.
-fn validate_accept_header(accept: &str) -> Result<(), String> {
+// Returns Ok iff the input string has a `application/signed-exchange;v=b3`,
+// and either accept_filter != PrefersSxg or its `q` value is 1.
+fn validate_accept_header(accept: &str, accept_filter: AcceptFilter) -> Result<(), String> {
     let accept = accept.trim();
     let accept = crate::http_parser::parse_accept_header(accept)?;
     if accept.len() == 0 {
@@ -241,10 +253,17 @@ fn validate_accept_header(accept: &str) -> Result<(), String> {
     const SXG: &str = "application/signed-exchange;v=b3";
     if q_sxg == 0 {
         Err(format!("The request accept header does not contain {}.", SXG))
-    } else if q_sxg < 1000 {
-        Err(format!("The q value of {} is less than 1 in request Accept header.", SXG))
     } else {
-        Ok(())
+        match accept_filter {
+            AcceptFilter::PrefersSxg => {
+                if q_sxg == 1000 {
+                    Ok(())
+                } else {
+                    Err(format!("The q value of {} is less than 1 in request Accept header.", SXG))
+                }
+            },
+            AcceptFilter::AcceptsSxg => Ok(()),
+        }
     }
 }
 
@@ -271,45 +290,46 @@ mod tests {
     // === forward_to_origin_server ===
     #[test]
     fn basic_request_headers() {
-      assert_eq!(headers(vec![("accept", "application/signed-exchange;v=b3")]).forward_to_origin_server(&HashSet::new()).unwrap().into_iter().collect::<HashMap<String, String>>(),
+      assert_eq!(headers(vec![("accept", "application/signed-exchange;v=b3")]).forward_to_origin_server(AcceptFilter::PrefersSxg, &HashSet::new()).unwrap().into_iter().collect::<HashMap<String, String>>(),
                  header_fields(vec![("user-agent", USER_AGENT), ("via", "sxgrs")]));
     }
     #[test]
     fn authenticated_request_headers() {
-      assert_eq!(headers(vec![("accept", "application/signed-exchange;v=b3"), ("authorization", "x")]).forward_to_origin_server(&HashSet::new()).unwrap_err(),
+      assert_eq!(headers(vec![("accept", "application/signed-exchange;v=b3"), ("authorization", "x")]).forward_to_origin_server(AcceptFilter::PrefersSxg, &HashSet::new()).unwrap_err(),
                  "The request contains an Authorization header.".to_string());
     }
 
     // === validate_accept_header ===
     #[test]
     fn basic_accept_header() {
-        assert!(validate_accept_header("application/signed-exchange;v=b3").is_ok());
-        assert!(validate_accept_header("application/signed-exchange;v=b3;q=1").is_ok());
-        assert!(validate_accept_header("application/signed-exchange;q=1;v=b3").is_err());
-        assert!(validate_accept_header("application/signed-exchange;v=b3;q=0.9,*/*;q=0.8").is_err());
-        assert!(validate_accept_header("").is_err());
-        assert!(validate_accept_header("text/html,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9").is_err());
+        assert!(validate_accept_header("application/signed-exchange;v=b3", AcceptFilter::PrefersSxg).is_ok());
+        assert!(validate_accept_header("application/signed-exchange;v=b3;q=1", AcceptFilter::PrefersSxg).is_ok());
+        assert!(validate_accept_header("application/signed-exchange;q=1;v=b3", AcceptFilter::PrefersSxg).is_err());
+        assert!(validate_accept_header("application/signed-exchange;v=b3;q=0.9,*/*;q=0.8", AcceptFilter::PrefersSxg).is_err());
+        assert!(validate_accept_header("", AcceptFilter::PrefersSxg).is_err());
+        assert!(validate_accept_header("text/html,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9", AcceptFilter::PrefersSxg).is_err());
     }
     #[test]
     fn optional_whitespaces() {
-        assert!(validate_accept_header("  application/signed-exchange  ;  v=b3  ;  q=1  ,  */*  ;  q=0.8  ").is_ok());
+        assert!(validate_accept_header("  application/signed-exchange  ;  v=b3  ;  q=1  ,  */*  ;  q=0.8  ", AcceptFilter::PrefersSxg).is_ok());
     }
     #[test]
     fn uppercase_q_and_v() {
-        assert!(validate_accept_header("text/html;q=0.5,application/signed-exchange;V=b3;Q=1").is_ok());
+        assert!(validate_accept_header("text/html;q=0.5,application/signed-exchange;V=b3;Q=1", AcceptFilter::PrefersSxg).is_ok());
     }
     #[test]
     fn default_q() {
-        assert!(validate_accept_header("text/html;q=0.5,application/signed-exchange;v=b3").is_ok());
+        assert!(validate_accept_header("text/html;q=0.5,application/signed-exchange;v=b3", AcceptFilter::PrefersSxg).is_ok());
     }
     #[test]
     fn missing_v() {
-        assert!(validate_accept_header("application/signed-exchange").is_err());
+        assert!(validate_accept_header("application/signed-exchange", AcceptFilter::PrefersSxg).is_err());
     }
     #[test]
     fn v_is_not_b3() {
-        assert!(validate_accept_header("application/signed-exchange;v=b2").is_err());
+        assert!(validate_accept_header("application/signed-exchange;v=b2", AcceptFilter::PrefersSxg).is_err());
     }
+    // TODO: test AcceptsSxg
 
     // === validate_as_sxg_payload ===
     #[test]

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -26,7 +26,7 @@ mod sxg;
 mod utils;
 
 use config::Config;
-use headers::Headers;
+use headers::{AcceptFilter, Headers};
 use http::{HeaderFields, HttpResponse};
 use serde::Serialize;
 
@@ -173,9 +173,9 @@ impl SxgWorker {
             }))
         }
     }
-    pub fn transform_request_headers(&self, fields: HeaderFields) -> Result<HeaderFields, String> {
+    pub fn transform_request_headers(&self, fields: HeaderFields, accept_filter: AcceptFilter) -> Result<HeaderFields, String> {
         let headers = Headers::new(fields, &self.config.strip_request_headers);
-        headers.forward_to_origin_server(&self.config.forward_request_headers)
+        headers.forward_to_origin_server(accept_filter, &self.config.forward_request_headers)
     }
     pub fn validate_payload_headers(&self, fields: HeaderFields) -> Result<(), String> {
         let headers = Headers::new(fields, &self.config.strip_response_headers);


### PR DESCRIPTION
This change from the previous behavior is a stopgap until
https://crbug.com/1243065 is fixed.

Fixes #32.

@antiphoton This means users will have to use an extension like ModHeader in order to visit the test endpoint. I think this is an acceptable trade-off given the problems with the above crbug, but if you'd like, I can update the code to ignore `Accept` for `PresetContent::ToBeSigned`.