### PR TITLE
Process Link header for cache requirements.

### DIFF
--- a/sxg_rs/src/http_parser/base.rs
+++ b/sxg_rs/src/http_parser/base.rs
@@ -35,7 +35,7 @@ pub fn token(input: &str) -> IResult<&str, &str> {
     take_while1(is_tchar)(input)
 }
 
-fn is_tchar(c: char) -> bool {
+pub fn is_tchar(c: char) -> bool {
     match c {
         '!' | '#' | '$' | '%' | '&' | '\'' | '*' => true,
         '+' | '-' | '.' | '^' | '_' | '`' | '|' | '~' => true,
@@ -83,7 +83,7 @@ fn is_qdtext(c: char) -> bool {
     }
 }
 
-fn is_quoted_pair_payload(c: char) -> bool {
+pub fn is_quoted_pair_payload(c: char) -> bool {
     match c {
         '\t' | ' ' => true,
         '\x21'..='\x7E' => true,

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -43,7 +43,7 @@ fn quote(value: &str) -> Option<String> {
         Some(value.into())
     } else if value.chars().all(|c| is_quoted_pair_payload(c)) {
         Some("\"".to_string() + &value.chars().map(|c: char| {
-            if c == '\\' or c == '"' {
+            if c == '\\' || c == '"' {
                 format!("\\{}", c)
             } else {
                 format!("{}", c)

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -58,12 +58,11 @@ impl <'a> Link<'a> {
     pub fn serialize(&self) -> String {
         "<".to_string() + self.uri + ">" +
             &self.params.iter().filter_map(|(k, v)| {
-                let directive = if let Some(v) = v {
-                  format!(";{}={}", k, quote(v)?)
+                Some(if let Some(v) = v {
+                    format!(";{}={}", k, quote(v)?)
                 } else {
-                  format!(";{}", k)
-                };
-                Some(directive)
+                    format!(";{}", k)
+                })
             }).collect::<String>()
     }
 }

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -1,0 +1,140 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use nom::{
+    IResult,
+    bytes::complete::take_while,
+    character::complete::char,
+    combinator::{map, opt},
+    multi::many0,
+    sequence::{delimited, pair, preceded, terminated, tuple},
+};
+use super::base::{
+    is_quoted_pair_payload,
+    is_tchar,
+    ows,
+    parameter_value,
+    token,
+};
+
+// Represents an individual link directive i.e. an instance of `link-value`
+// from https://datatracker.ietf.org/doc/html/rfc8288#section-3.
+// Parameters with alternate character encodings (via RFC8187) are not
+// supported.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Link<'a> {
+    pub uri: &'a str,
+    pub params: Vec<(&'a str, Option<String>)>,
+}
+
+fn quote(value: &str) -> Option<String> {
+    if value.chars().all(|c| is_tchar(c)) {
+        Some(value.into())
+    } else if value.chars().all(|c| is_quoted_pair_payload(c)) {
+        Some("\"".to_string() + &value.chars().map(|c: char| {
+            let mut quoted_pair = if c == '\\' || c == '"' {
+                "\\"
+            } else {
+                ""
+            }.to_string();
+            quoted_pair.push(c);
+            quoted_pair
+        }).collect::<String>() + "\"")
+    } else {
+        None
+    }
+}
+
+impl <'a> Link<'a> {
+    pub fn serialize(&self) -> String {
+        "<".to_string() + self.uri + ">" +
+            &self.params.iter().filter_map(|(k, v)| {
+                let mut directive = ";".to_string() + k;
+                if let Some(v) = v {
+                    if let Some(quoted) = quote(v) {
+                        directive.push('=');
+                        directive.push_str(&quoted);
+                    } else {
+                        return None
+                    }
+                }
+                Some(directive)
+            }).collect::<String>()
+    }
+}
+
+fn uri_ref(input: &str) -> IResult<&str, &str> {
+    // We don't need to fully parse the URI ref using nom. It would be
+    // sufficient to scan up until the closing delimiter '>' and then pass the result to the
+    // URL class for parsing and validation. For defense in depth, we only allow
+    // the characters specified in
+    // https://datatracker.ietf.org/doc/html/rfc3986#appendix-A.
+    take_while(|c: char|
+        match c {
+            // unreserved
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' => true,
+            // gen-delims
+            ':' | '|' | '?' | '#' | '[' | ']' | '@' => true,
+            // sub-delims
+            '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' => true,
+            // pct-encoded
+            '%' => true,
+            // path
+            '/' => true,
+            _ => false,
+        }
+    )(input)
+}
+
+fn link_param<'a>(input: &'a str) -> IResult<&str, (&'a str, Option<String>)> {
+    pair(terminated(token, ows),
+         opt(preceded(pair(char('='), ows), parameter_value)))(input)
+}
+
+pub fn link(input: &str) -> IResult<&str, Link> {
+    map(pair(delimited(char('<'), uri_ref, char('>')),
+             many0(preceded(tuple((ows, char(';'), ows)), link_param))), |(uri, params)|
+        Link{uri, params}
+    )(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parse() {
+        assert_eq!(link("<>").unwrap(), ("", Link{uri: "", params: vec![]}));
+        assert_eq!(link("</foo,bar;baz>").unwrap(), ("", Link{uri: "/foo,bar;baz", params: vec![]}));
+        assert_eq!(link("</foo>;bar;baz=quux").unwrap(),
+                   ("", Link{uri: "/foo",
+                             params: vec![("bar", None), ("baz", Some("quux".into()))]}));
+        assert_eq!(link(r#"</foo>;bar="baz \\\"quux""#).unwrap(),
+                   ("", Link{uri: "/foo",
+                             params: vec![("bar", Some(r#"baz \"quux"#.into()))]}));
+        assert!(matches!(link(r#"</foo>;bar="baz \""#).unwrap_err(), nom::Err::Incomplete(_)));
+    }
+    #[test]
+    fn serialize() {
+        assert_eq!(Link{uri: "/foo", params: vec![("bar", None)]}.serialize(),
+                   "</foo>;bar");
+        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some("baz".into()))]}.serialize(),
+                   "</foo>;bar=baz");
+        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some("baz quux".into()))]}.serialize(),
+                   r#"</foo>;bar="baz quux""#);
+        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some(r#"baz\"quux"#.into()))]}.serialize(),
+                   r#"</foo>;bar="baz\\\"quux""#);
+        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some("\x7f".into()))]}.serialize(),
+                   "</foo>");
+    }
+}

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -43,13 +43,11 @@ fn quote(value: &str) -> Option<String> {
         Some(value.into())
     } else if value.chars().all(|c| is_quoted_pair_payload(c)) {
         Some("\"".to_string() + &value.chars().map(|c: char| {
-            let mut quoted_pair = if c == '\\' || c == '"' {
-                "\\"
+            if c == '\\' or c == '"' {
+                format!("\\{}", c)
             } else {
-                ""
-            }.to_string();
-            quoted_pair.push(c);
-            quoted_pair
+                format!("{}", c)
+            }
         }).collect::<String>() + "\"")
     } else {
         None
@@ -60,15 +58,11 @@ impl <'a> Link<'a> {
     pub fn serialize(&self) -> String {
         "<".to_string() + self.uri + ">" +
             &self.params.iter().filter_map(|(k, v)| {
-                let mut directive = ";".to_string() + k;
-                if let Some(v) = v {
-                    if let Some(quoted) = quote(v) {
-                        directive.push('=');
-                        directive.push_str(&quoted);
-                    } else {
-                        return None
-                    }
-                }
+                let directive = if let Some(v) = v {
+                  format!(";{}={}", k, quote(v)?)
+                } else {
+                  format!(";{}", k)
+                };
                 Some(directive)
             }).collect::<String>()
     }

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -16,6 +16,7 @@ mod accept;
 mod base;
 mod cache_control;
 pub mod media_type;
+pub mod link;
 
 use nom::{
     IResult,
@@ -50,14 +51,18 @@ pub fn parse_accept_header(input: &str) -> Result<Vec<accept::Accept>, String> {
     parse_vec(input, accept::accept)
 }
 
+// Returns the freshness lifetime for a shared cache.
+pub fn parse_cache_control_header(input: &str) -> Result<Duration, String> {
+    let directives = parse_vec(input, cache_control::directive)?;
+    cache_control::freshness_lifetime(directives).ok_or("Freshness lifetime is implicit".into())
+}
+
 pub fn parse_content_type_header(input: &str) -> Result<media_type::MediaType, String> {
     complete(media_type::media_type)(input)
         .map(|(_, output)| output)
         .map_err(format_nom_err)
 }
 
-// Returns the freshness lifetime for a shared cache.
-pub fn parse_cache_control_header(input: &str) -> Result<Duration, String> {
-    let directives = parse_vec(input, cache_control::directive)?;
-    cache_control::freshness_lifetime(directives).ok_or("Freshness lifetime is implicit".into())
+pub fn parse_link_header(input: &str) -> Result<Vec<link::Link>, String> {
+    parse_vec(input, link::link)
 }

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -89,7 +89,7 @@ impl SxgWorker {
         // 16384 is the max mice record size allowed by SXG spec.
         // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#section-3.5-7.9.1
         let (mice_digest, payload_body) = crate::mice::calculate(payload_body, 16384);
-        let signed_headers = payload_headers.get_signed_headers_bytes(status_code, &mice_digest);
+        let signed_headers = payload_headers.get_signed_headers_bytes(&fallback_base, status_code, &mice_digest);
         let cert_url = cert_base.join(&format!("{}{}", &self.config.cert_url_dirname, &self.cert_basename()))
             .map_err(|_| "Failed to parse cert_url_dirname")?;
         let validity_url = fallback_base.join(&format!("{}{}", &self.config.validity_url_dirname, "validity"))


### PR DESCRIPTION
Parse and transform the Link header to meet the Google SXG Cache requirements
at https://github.com/google/webpackager/blob/main/docs/cache_requirements.md.

Directives are omitted if they have an invalid rel or crossorigin or an unknown
param name. Hrefs are converted to absolute URLs. Preloads are limited to 20.
imagesrcset and imagesizes are not yet validated.

A future commit will compute header-integrity and add appropriate
allowed-alt-sxg directives.

Addresses #13.