### PR TITLE
Use anyhow crate for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arc-swap"
@@ -405,6 +405,7 @@ dependencies = [
 name = "cloudflare_worker"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.13.0",
  "console_error_panic_hook",
  "js-sys",
@@ -461,6 +462,7 @@ dependencies = [
 name = "config-generator"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cloudflare",
  "console 0.14.1",
  "ctrlc",
@@ -1051,6 +1053,7 @@ dependencies = [
 name = "fastly_compute"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.13.0",
  "fastly",
@@ -3026,6 +3029,7 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 name = "sxg_rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.13.0",
  "der-parser",

--- a/cloudflare_worker/Cargo.toml
+++ b/cloudflare_worker/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+anyhow = "1.0.43"
 base64 = "0.13.0"
 console_error_panic_hook = "0.1.6"
 js-sys = "0.3.50"

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -19,6 +19,7 @@ use once_cell::sync::OnceCell;
 use sxg_rs::SxgWorker;
 use sxg_rs::headers::AcceptFilter;
 use sxg_rs::http::HttpResponse;
+use utils::anyhow_error_to_js_value;
 use wasm_bindgen::prelude::*;
 
 static WORKER: OnceCell<SxgWorker> = OnceCell::new();
@@ -74,7 +75,7 @@ pub fn create_request_headers(accept_filter: JsValue, requestor_headers: JsValue
             Ok(JsValue::from_serde(&fields).unwrap())
         },
         Err(err) => {
-            Err(JsValue::from_str(&err))
+            Err(anyhow_error_to_js_value(err))
         },
     }
 }
@@ -83,7 +84,7 @@ pub fn create_request_headers(accept_filter: JsValue, requestor_headers: JsValue
 pub fn validate_payload_headers(fields: JsValue) -> Result<(), JsValue> {
     let fields = fields.into_serde().unwrap();
     let result = get_worker()?.validate_payload_headers(fields);
-    result.map_err(|err| JsValue::from_str(&err))
+    result.map_err(anyhow_error_to_js_value)
 }
 
 #[wasm_bindgen(js_name=createSignedExchange)]
@@ -106,6 +107,6 @@ pub async fn create_signed_exchange(
         payload_headers,
         signer,
         status_code,
-    }).await.map_err(|err| JsValue::from_str(&err))?;
+    }).await.map_err(anyhow_error_to_js_value)?;
     Ok(JsValue::from_serde(&sxg).unwrap())
 }

--- a/cloudflare_worker/src/utils.rs
+++ b/cloudflare_worker/src/utils.rs
@@ -43,3 +43,6 @@ pub fn get_last_error_message() -> JsValue {
     }
 }
 
+pub fn anyhow_error_to_js_value(error: anyhow::Error) -> JsValue {
+    JsValue::from_str(&format!("{:?}", error))
+}

--- a/config_generator/Cargo.toml
+++ b/config_generator/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.43"
 cloudflare = "0.8.6"
 console = "0.14.1"
 ctrlc = "3.2.0"

--- a/config_generator/src/main.rs
+++ b/config_generator/src/main.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Error, Result};
 use console::Term;
 use dialoguer::{Input, Select};
 use serde::{Deserialize, Serialize};
@@ -90,9 +91,9 @@ fn get_ocsp_kv_id(user: &GlobalUser, account_id: &str) -> String {
     namespace.id
 }
 
-fn read_certificate_pem_file(path: &str) -> Result<String, String> {
+fn read_certificate_pem_file(path: &str) -> Result<String> {
     let text =
-        std::fs::read_to_string(path).map_err(|_| format!(r#"Failed to read file "{}""#, path))?;
+        std::fs::read_to_string(path).map_err(|_| Error::msg(format!(r#"Failed to read file "{}""#, path)))?;
     // Translate Windows-style line endings to Unix-style so the '\r' is
     // not rendered in the toml. This is purely cosmetic; '\r' is deserialized
     // faithfully from toml and pem::parse_many is able to parse either style.
@@ -101,7 +102,7 @@ fn read_certificate_pem_file(path: &str) -> Result<String, String> {
     if certs.len() == 1 && certs[0].tag == "CERTIFICATE" {
         Ok(text)
     } else {
-        Err(format!(r#"File "{}" is not a valid certificate PEM"#, path))
+        Err(Error::msg(format!(r#"File "{}" is not a valid certificate PEM"#, path)))
     }
 }
 

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -23,6 +23,7 @@ publish = false
 debug = false
 
 [dependencies]
+anyhow = "1.0.43"
 async-trait = "0.1.50"
 base64 = "0.13.0"
 fastly = "^0.7.3"

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -28,6 +28,7 @@ rust_signer = []
 strip_id_headers = []
 
 [dependencies]
+anyhow = "1.0.43"
 async-trait = "0.1.50"
 base64 = "0.13.0"
 der-parser = { version = "5.1.0", features = ["bigint", "serialize"] }

--- a/sxg_rs/src/fetcher/js_fetcher.rs
+++ b/sxg_rs/src/fetcher/js_fetcher.rs
@@ -42,9 +42,9 @@ impl Fetcher for JsFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
         let request = JsValue::from_serde(&request).map_err(|e| Error::new(e).context("Failed to parse request."))?;
         let this = JsValue::null();
-        let response = self.0.call1(&this, &request).map_err(|_| Error::msg("JavaScript fetcher throws an error."))?;
+        let response = self.0.call1(&this, &request).map_err(|e| Error::msg(format!("{:?}", e)).context("JavaScript fetcher throws an error."))?;
         let response = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(response));
-        let response = response.await.map_err(|_| Error::msg("JavaScript fetcher throws an error asynchronously."))?;
+        let response = response.await.map_err(|e| Error::msg(format!("{:?}", e)).context("JavaScript fetcher throws an error asynchronously."))?;
         let response: HttpResponse = response.into_serde().map_err(|e| Error::new(e).context("Failed to serialize response."))?;
         Ok(response)
     }

--- a/sxg_rs/src/fetcher/mod.rs
+++ b/sxg_rs/src/fetcher/mod.rs
@@ -15,11 +15,12 @@
 #[cfg(feature="js_fetcher")]
 pub mod js_fetcher;
 
+use anyhow::Result;
 use async_trait::async_trait;
 use crate::http::{HttpRequest, HttpResponse};
 
 /// An interface for fetching resources from network.
 #[async_trait(?Send)]
 pub trait Fetcher {
-    async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse, String>;
+    async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse>;
 }

--- a/sxg_rs/src/signature/js_signer.rs
+++ b/sxg_rs/src/signature/js_signer.rs
@@ -75,11 +75,13 @@ impl Signer for JsSigner {
 }
 
 fn raw_sig_to_asn1(raw: Vec<u8>) -> Result<Vec<u8>> {
-    if raw.len() != 64 {
-        return Err(Error::msg(format!("Expecting signature length to be 64, found {}.", raw.len())));
+    const NUMBER_LENGTH: usize = 32;  // 256 bit is 32 bytes.
+    const SIG_LENGTH: usize = NUMBER_LENGTH * 2;  // A signature contains two numbers;
+    if raw.len() != SIG_LENGTH {
+        return Err(Error::msg(format!("Expecting signature length to be {}, found {}.", SIG_LENGTH, raw.len())));
     }
     let mut r = raw;
-    let mut s = r.split_off(32);
+    let mut s = r.split_off(NUMBER_LENGTH);
     ensure_positive(&mut r);
     ensure_positive(&mut s);
     let asn1 = BerObject::from_obj(BerObjectContent::Sequence(vec![

--- a/sxg_rs/src/signature/js_signer.rs
+++ b/sxg_rs/src/signature/js_signer.rs
@@ -61,9 +61,9 @@ impl Signer for JsSigner {
         let a = Uint8Array::new_with_length(message.len() as u32);
         a.copy_from(&message);
         let this = JsValue::null();
-        let sig = self.js_function.call1(&this, &a).map_err(|_| Error::msg("JavaScript signer throws an error."))?;
+        let sig = self.js_function.call1(&this, &a).map_err(|e| Error::msg(format!("{:?}", e)).context("JavaScript signer throws an error."))?;
         let sig = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(sig));
-        let sig = sig.await.map_err(|_| Error::msg("JavaScript signer throws an error asynchronously."))?;
+        let sig = sig.await.map_err(|e| Error::msg(format!("{:?}", e)).context("JavaScript signer throws an error asynchronously."))?;
         let sig = Uint8Array::from(sig);
         let sig = sig.to_vec();
         let sig = match self.js_sig_format {

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -17,13 +17,14 @@ pub mod js_signer;
 #[cfg(feature="rust_signer")]
 pub mod rust_signer;
 
+use anyhow::Result;
 use async_trait::async_trait;
 use crate::structured_header::{ShItem, ShParamList, ParamItem};
 
 #[async_trait(?Send)]
 pub trait Signer {
     /// Signs the message, and returns `ASN.1` format.
-    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>, String>;
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>>;
 }
 
 pub struct SignatureParams<'a> {
@@ -50,7 +51,7 @@ pub struct Signature<'a> {
 }
 
 impl<'a> Signature<'a> {
-    pub async fn new(params: SignatureParams<'a>) -> Result<Signature<'a>,String> {
+    pub async fn new(params: SignatureParams<'a>) -> Result<Signature<'a>> {
         let SignatureParams {
             cert_url,
             cert_sha256,
@@ -80,7 +81,7 @@ impl<'a> Signature<'a> {
             &(headers.len() as u64).to_be_bytes(),
             &headers,
         ].concat();
-        let sig = signer.sign(&message).await.map_err(|_| "Signer error")?;
+        let sig = signer.sign(&message).await.map_err(|e| e.context("Failed to sign the message."))?;
         Ok(Signature {
             cert_url,
             cert_sha256,

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Result;
 use async_trait::async_trait;
 use p256::ecdsa::SigningKey;
 use super::Signer;
@@ -23,17 +24,15 @@ pub struct RustSigner {
 impl RustSigner {
     pub fn new(private_key: &[u8]) -> Self {
         let private_key = SigningKey::from_bytes(private_key).unwrap();
-        RustSigner {
-            private_key,
-        }
+        RustSigner { private_key }
     }
 }
 
 #[async_trait(?Send)]
 impl Signer for RustSigner {
-    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>,String> {
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
         use p256::ecdsa::signature::Signer as _;
-        let sig = self.private_key.sign(&message).to_asn1();
+        let sig = self.private_key.try_sign(&message)?.to_asn1();
         Ok(sig.as_bytes().to_vec())
     }
 }

--- a/sxg_rs/src/sxg.rs
+++ b/sxg_rs/src/sxg.rs
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Error, Result};
+
 // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#application-signed-exchange
-pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payload_body: &[u8]) -> Result<Vec<u8>, String> {
+pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payload_body: &[u8]) -> Result<Vec<u8>> {
     // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#name-application-signed-exchange
     if signature.len() > 16384 {
-        return Err("sigLength is larger than 16384".into())
+        return Err(Error::msg("sigLength is larger than 16384"));
     }
     if signed_headers.len() > 524288 {
-        return Err("headerLength is larger than 524288".into())
+        return Err(Error::msg("headerLength is larger than 524288"));
     }
     Ok([
         "sxg1-b3\0".as_bytes(),

--- a/sxg_rs/src/sxg.rs
+++ b/sxg_rs/src/sxg.rs
@@ -17,18 +17,22 @@ use anyhow::{Error, Result};
 // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#application-signed-exchange
 pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payload_body: &[u8]) -> Result<Vec<u8>> {
     // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#name-application-signed-exchange
-    if signature.len() > 16384 {
-        return Err(Error::msg("sigLength is larger than 16384"));
+    const SIG_LEN_LIMIT: usize = 16384;
+    let sig_len = signature.len();
+    if sig_len > SIG_LEN_LIMIT {
+        return Err(Error::msg(format!("sigLength {} is and larger than the limit {}", sig_len, SIG_LEN_LIMIT)));
     }
-    if signed_headers.len() > 524288 {
-        return Err(Error::msg("headerLength is larger than 524288"));
+    const HEADER_LEN_LIMIT: usize = 524288;
+    let header_len = signed_headers.len();
+    if header_len > HEADER_LEN_LIMIT {
+        return Err(Error::msg(format!("headerLength {} is larger than the limit {}", header_len, HEADER_LEN_LIMIT)));
     }
     Ok([
         "sxg1-b3\0".as_bytes(),
         &(fallback_url.len() as u16).to_be_bytes(),
         fallback_url.as_bytes(),
-        (signature.len() as u32).to_be_bytes().get(1..4).unwrap(),
-        (signed_headers.len() as u32).to_be_bytes().get(1..4).unwrap(),
+        (sig_len as u32).to_be_bytes().get(1..4).unwrap(),
+        (header_len as u32).to_be_bytes().get(1..4).unwrap(),
         signature,
         signed_headers,
         payload_body,


### PR DESCRIPTION
- In the return value of all functions, change `std::result::Result<T, String>` to `anyhow::Result<T>` .
- In `map_err` closures, use `anyhow::Result::context()` to create error chain.