### PR TITLE
Use rustfmt to format Rust code

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Code Style
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  Rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Unit tests
 on:
   push:

--- a/cloudflare_worker/src/utils.rs
+++ b/cloudflare_worker/src/utils.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use once_cell::sync::Lazy;
 use std::panic;
 use std::sync::{Mutex, Once};
-use once_cell::sync::Lazy;
 use wasm_bindgen::JsValue;
 
-pub static LAST_ERROR_MESSAGE: Lazy<Mutex<String>> = Lazy::new(|| {
-    Mutex::new("".to_string())
-});
+pub static LAST_ERROR_MESSAGE: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new("".to_string()));
 
 fn hook(info: &panic::PanicInfo) {
     console_error_panic_hook::hook(info);
@@ -39,7 +37,9 @@ pub fn get_last_error_message() -> JsValue {
     if let Ok(last_error_message) = LAST_ERROR_MESSAGE.try_lock() {
         JsValue::from_str(&last_error_message)
     } else {
-        JsValue::from_str("Last error message is not available, because it is locked by another thread.")
+        JsValue::from_str(
+            "Last error message is not available, because it is locked by another thread.",
+        )
     }
 }
 

--- a/config_generator/src/main.rs
+++ b/config_generator/src/main.rs
@@ -92,8 +92,8 @@ fn get_ocsp_kv_id(user: &GlobalUser, account_id: &str) -> String {
 }
 
 fn read_certificate_pem_file(path: &str) -> Result<String> {
-    let text =
-        std::fs::read_to_string(path).map_err(|_| Error::msg(format!(r#"Failed to read file "{}""#, path)))?;
+    let text = std::fs::read_to_string(path)
+        .map_err(|_| Error::msg(format!(r#"Failed to read file "{}""#, path)))?;
     // Translate Windows-style line endings to Unix-style so the '\r' is
     // not rendered in the toml. This is purely cosmetic; '\r' is deserialized
     // faithfully from toml and pem::parse_many is able to parse either style.
@@ -102,7 +102,10 @@ fn read_certificate_pem_file(path: &str) -> Result<String> {
     if certs.len() == 1 && certs[0].tag == "CERTIFICATE" {
         Ok(text)
     } else {
-        Err(Error::msg(format!(r#"File "{}" is not a valid certificate PEM"#, path)))
+        Err(Error::msg(format!(
+            r#"File "{}" is not a valid certificate PEM"#,
+            path
+        )))
     }
 }
 
@@ -141,7 +144,8 @@ const CONFIG_EXAMPLE_FILE: &'static str = "cloudflare_worker/wrangler.example.to
 // This function panics if `wrangler.toml` contains syntax error,
 // even when a valid `wrangler.example.toml` exists.
 fn read_existing_config() -> (WranglerConfig, bool) {
-    let (wrangler_config, exists) = std::fs::read_to_string(CONFIG_FILE).map (|s| (s, true))
+    let (wrangler_config, exists) = std::fs::read_to_string(CONFIG_FILE)
+        .map(|s| (s, true))
         .or_else(|_| std::fs::read_to_string(CONFIG_EXAMPLE_FILE).map(|s| (s, false)))
         .unwrap();
     let wrangler_config: WranglerConfig = toml::from_str(&wrangler_config).unwrap();
@@ -179,8 +183,10 @@ fn main() -> Result<(), std::io::Error> {
             .unwrap();
         let target = Select::new()
             .with_prompt("Where do you want to deploy the worker?")
-            .items(&vec!["On your domain (recommended; required by Google SXG Cache)",
-                         "On workers.dev (development only)"])
+            .items(&vec![
+                "On your domain (recommended; required by Google SXG Cache)",
+                "On workers.dev (development only)",
+            ])
             .default(0)
             .interact()
             .unwrap();

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -14,17 +14,10 @@
 
 use anyhow::{Error, Result};
 use async_trait::async_trait;
-use fastly::{
-    Request as FastlyRequest,
-    Response as FastlyResponse,
-};
+use fastly::{Request as FastlyRequest, Response as FastlyResponse};
 use sxg_rs::{
     fetcher::Fetcher,
-    http::{
-        HttpRequest,
-        HttpResponse,
-        Method,
-    },
+    http::{HttpRequest, HttpResponse, Method},
 };
 
 /// A [`Fetcher`] implemented by
@@ -49,9 +42,9 @@ impl FastlyFetcher {
 impl Fetcher for FastlyFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
         let request = from_http_request(request);
-        let response: FastlyResponse = request.send(self.backend_name).map_err(|e| {
-            Error::new(e).context("Failed to fetch from backend.")
-        })?;
+        let response: FastlyResponse = request
+            .send(self.backend_name)
+            .map_err(|e| Error::new(e).context("Failed to fetch from backend."))?;
         into_http_response(response)
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,16 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+newline_style = "Unix"
+

--- a/sxg_rs/src/cbor.rs
+++ b/sxg_rs/src/cbor.rs
@@ -38,17 +38,17 @@ impl<'a> DataItem<'a> {
             ByteString(bytes) => {
                 append_integer(output, 2, bytes.len() as u64);
                 output.extend_from_slice(bytes);
-            },
+            }
             TextString(text) => {
                 append_integer(output, 3, text.len() as u64);
                 output.extend_from_slice(text.as_bytes());
-            },
+            }
             Array(items) => {
                 append_integer(output, 4, items.len() as u64);
                 for item in items {
                     item.append_binary_to(output);
                 }
-            },
+            }
             Map(fields) => {
                 let mut map = BTreeMap::<Vec<u8>, Vec<u8>>::new();
                 for (key, value) in fields {
@@ -59,7 +59,7 @@ impl<'a> DataItem<'a> {
                     output.append(&mut key);
                     output.append(&mut value);
                 }
-            },
+            }
         }
     }
 }
@@ -69,23 +69,23 @@ fn append_integer(output: &mut Vec<u8>, major_type: u8, data: u64) {
     match data {
         0..=23 => {
             output.push(major_type | (data as u8));
-        },
+        }
         24..=0xff => {
             output.push(major_type | 24);
             output.push(data as u8);
-        },
+        }
         0x100..=0xffff => {
             output.push(major_type | 25);
             output.extend_from_slice(&(data as u16).to_be_bytes());
-        },
+        }
         0x10000..=0xffffffff => {
             output.push(major_type | 26);
             output.extend_from_slice(&(data as u32).to_be_bytes());
-        },
+        }
         0x100000000..=0xffffffffffffffff => {
             output.push(major_type | 27);
             output.extend_from_slice(&data.to_be_bytes());
-        },
+        }
     };
 }
 
@@ -93,28 +93,17 @@ fn append_integer(output: &mut Vec<u8>, major_type: u8, data: u64) {
 mod tests {
     use super::*;
     fn from_hex(input: &str) -> Vec<u8> {
-        (0..input.len()).step_by(2).map(|i| {
-            u8::from_str_radix(&input[i..i + 2], 16).unwrap()
-        }).collect()
+        (0..input.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&input[i..i + 2], 16).unwrap())
+            .collect()
     }
     #[test]
     fn it_works() {
-        assert_eq!(
-            DataItem::UnsignedInteger(0).serialize(),
-            from_hex("00"),
-        );
-        assert_eq!(
-            DataItem::UnsignedInteger(23).serialize(),
-            from_hex("17"),
-        );
-        assert_eq!(
-            DataItem::UnsignedInteger(24).serialize(),
-            from_hex("1818"),
-        );
-        assert_eq!(
-            DataItem::UnsignedInteger(100).serialize(),
-            from_hex("1864"),
-        );
+        assert_eq!(DataItem::UnsignedInteger(0).serialize(), from_hex("00"),);
+        assert_eq!(DataItem::UnsignedInteger(23).serialize(), from_hex("17"),);
+        assert_eq!(DataItem::UnsignedInteger(24).serialize(), from_hex("1818"),);
+        assert_eq!(DataItem::UnsignedInteger(100).serialize(), from_hex("1864"),);
         assert_eq!(
             DataItem::UnsignedInteger(1000).serialize(),
             from_hex("1903e8"),
@@ -139,15 +128,13 @@ mod tests {
             DataItem::TextString("IETF").serialize(),
             from_hex("6449455446"),
         );
-        assert_eq!(
-            DataItem::Map(vec![]).serialize(),
-            from_hex("a0"),
-        );
+        assert_eq!(DataItem::Map(vec![]).serialize(), from_hex("a0"),);
         assert_eq!(
             DataItem::Map(vec![
                 (DataItem::UnsignedInteger(1), DataItem::UnsignedInteger(2)),
                 (DataItem::UnsignedInteger(3), DataItem::UnsignedInteger(4)),
-            ]).serialize(),
+            ])
+            .serialize(),
             from_hex("a201020304"),
         );
     }
@@ -156,9 +143,10 @@ mod tests {
         use DataItem::*;
         assert_eq!(
             Map(vec![
-              (UnsignedInteger(2), UnsignedInteger(5)),
-              (UnsignedInteger(1), UnsignedInteger(6)),
-            ]).serialize(),
+                (UnsignedInteger(2), UnsignedInteger(5)),
+                (UnsignedInteger(1), UnsignedInteger(6)),
+            ])
+            .serialize(),
             from_hex("a201060205"),
         );
         // Although "AA" is lexicographically less than "B", the CBOR format
@@ -166,9 +154,10 @@ mod tests {
         // than "AA".
         assert_eq!(
             Map(vec![
-              (TextString("AA"), UnsignedInteger(6)),
-              (TextString("B"), UnsignedInteger(5)),
-            ]).serialize(),
+                (TextString("AA"), UnsignedInteger(6)),
+                (TextString("B"), UnsignedInteger(5)),
+            ])
+            .serialize(),
             from_hex("a261420562414106"),
         );
     }

--- a/sxg_rs/src/config.rs
+++ b/sxg_rs/src/config.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 // This struct is source-of-truth of the sxg config. The user need to create
 // a file (like `config.yaml`) to provide this config input.
@@ -96,8 +96,8 @@ fn get_der(pem_text: &str, expected_tag: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::tests::SELF_SIGNED_CERT_PEM;
     use super::*;
+    use crate::utils::tests::SELF_SIGNED_CERT_PEM;
     #[test]
     fn processes_input() {
         let yaml = r#"
@@ -114,10 +114,25 @@ validity_url_dirname: "//.well-known/sxg-validity"
         "#;
         let config = Config::new(yaml, SELF_SIGNED_CERT_PEM, SELF_SIGNED_CERT_PEM);
         assert_eq!(config.cert_url_dirname, "/.well-known/sxg-certs/");
-        assert_eq!(config.forward_request_headers, ["cf-ipcountry", "user-agent"].iter().map(|s| s.to_string()).collect());
+        assert_eq!(
+            config.forward_request_headers,
+            ["cf-ipcountry", "user-agent"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        );
         assert_eq!(config.html_host, Some("my_domain.com".into()));
-        assert_eq!(config.strip_request_headers, ["forwarded"].iter().map(|s| s.to_string()).collect());
-        assert_eq!(config.strip_response_headers, ["set-cookie", "strict-transport-security"].iter().map(|s| s.to_string()).collect());
+        assert_eq!(
+            config.strip_request_headers,
+            ["forwarded"].iter().map(|s| s.to_string()).collect()
+        );
+        assert_eq!(
+            config.strip_response_headers,
+            ["set-cookie", "strict-transport-security"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        );
         assert_eq!(config.reserved_path, "/.sxg/");
         assert_eq!(config.validity_url_dirname, "/.well-known/sxg-validity/");
     }

--- a/sxg_rs/src/fetcher/mod.rs
+++ b/sxg_rs/src/fetcher/mod.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature="js_fetcher")]
+#[cfg(feature = "js_fetcher")]
 pub mod js_fetcher;
 
+use crate::http::{HttpRequest, HttpResponse};
 use anyhow::Result;
 use async_trait::async_trait;
-use crate::http::{HttpRequest, HttpResponse};
 
 /// An interface for fetching resources from network.
 #[async_trait(?Send)]

--- a/sxg_rs/src/http.rs
+++ b/sxg_rs/src/http.rs
@@ -36,4 +36,3 @@ pub enum Method {
     Get,
     Post,
 }
-

--- a/sxg_rs/src/http_parser/accept.rs
+++ b/sxg_rs/src/http_parser/accept.rs
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nom::{
-    map,
-    named,
-};
-use super::media_type::{
-    MediaType,
-    Parameter,
-    media_type,
-};
+use super::media_type::{media_type, MediaType, Parameter};
+use nom::{map, named};
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Accept<'a> {
@@ -62,12 +55,12 @@ named!(
 );
 
 fn parse_q_millis(s: &str) -> Option<u16> {
-  let x = s.parse::<f64>().ok()?;
-  if x >= 0.0 && x <= 1.0 {
-      Some((x * 1000.0) as u16)
-  } else {
-      None
-  }
+    let x = s.parse::<f64>().ok()?;
+    if x >= 0.0 && x <= 1.0 {
+        Some((x * 1000.0) as u16)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -83,12 +76,10 @@ mod tests {
                     media_range: MediaType {
                         primary_type: "text",
                         sub_type: "html",
-                        parameters: vec![
-                            Parameter {
-                                name: "charset",
-                                value: "utf-8".to_string(),
-                            }
-                        ],
+                        parameters: vec![Parameter {
+                            name: "charset",
+                            value: "utf-8".to_string(),
+                        }],
                     },
                     q_millis: 900,
                     extensions: vec![],

--- a/sxg_rs/src/http_parser/base.rs
+++ b/sxg_rs/src/http_parser/base.rs
@@ -13,20 +13,10 @@
 // limitations under the License.
 
 use nom::{
-    IResult,
     alt,
-    bytes::complete::{
-        take_while,
-        take_while1,
-    },
+    bytes::complete::{take_while, take_while1},
     character::complete::char as char1,
-    delimited,
-    many0,
-    map,
-    map_opt,
-    named,
-    preceded,
-    take,
+    delimited, many0, map, map_opt, named, preceded, take, IResult,
 };
 
 // `token` are defined in
@@ -79,7 +69,7 @@ fn is_qdtext(c: char) -> bool {
         '\t' | ' ' | '\x21' => true,
         '\x23'..='\x5B' | '\x5D'..='\x7E' => true,
         '\u{80}'..=std::char::MAX => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -88,7 +78,7 @@ pub fn is_quoted_pair_payload(c: char) -> bool {
         '\t' | ' ' => true,
         '\x21'..='\x7E' => true,
         '\u{80}'..=std::char::MAX => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -97,20 +87,16 @@ named!(
     preceded!(char1('\\'), char_if(is_quoted_pair_payload))
 );
 
-fn char_if(predicate: fn (c: char) -> bool) -> impl Fn(&str) -> IResult<&str, char> {
+fn char_if(predicate: fn(c: char) -> bool) -> impl Fn(&str) -> IResult<&str, char> {
     move |input: &str| {
-        map_opt!(
-            input,
-            take!(1),
-            |s: &str| {
-                let c = s.chars().nth(0)?;
-                if predicate(c) {
-                    Some(c)
-                } else {
-                    None
-                }
+        map_opt!(input, take!(1), |s: &str| {
+            let c = s.chars().nth(0)?;
+            if predicate(c) {
+                Some(c)
+            } else {
+                None
             }
-        )
+        })
     }
 }
 
@@ -132,26 +118,19 @@ mod tests {
         assert_eq!(
             token("amp⚡").unwrap(),
             (
-                "⚡",  // unparsed bytes
-                "amp",  // parsed token
+                "⚡", // unparsed bytes
+                "amp", // parsed token
             )
         );
         // `obs-text` are allowed in quoted-string.
         assert_eq!(
             quoted_string(r#""amp⚡s""#).unwrap(),
-            (
-                "",
-                "amp⚡s".to_string(),
-            )
+            ("", "amp⚡s".to_string(),)
         );
         // `obs-text` are allowed as quoted-pair.
         assert_eq!(
             quoted_string(r#""amp\⚡s""#).unwrap(),
-            (
-                "",
-                "amp⚡s".to_string(),
-            )
+            ("", "amp⚡s".to_string(),)
         );
-
     }
 }

--- a/sxg_rs/src/http_parser/cache_control.rs
+++ b/sxg_rs/src/http_parser/cache_control.rs
@@ -12,22 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::base::{parameter_value, token};
 use nom::{
-    IResult,
-    branch::alt,
-    bytes::complete::tag_no_case,
-    character::complete::char,
-    combinator::map,
-    combinator::map_res,
-    combinator::opt,
-    sequence::pair,
-    sequence::preceded,
+    branch::alt, bytes::complete::tag_no_case, character::complete::char, combinator::map,
+    combinator::map_res, combinator::opt, sequence::pair, sequence::preceded, IResult,
 };
 use std::time::Duration;
-use super::base::{
-    parameter_value,
-    token,
-};
 
 // https://datatracker.ietf.org/doc/html/rfc7234#section-5.2
 #[derive(Clone, Debug, PartialEq)]
@@ -43,13 +33,21 @@ pub fn directive(input: &str) -> IResult<&str, Directive> {
         // Nonnegative integers up to 31 bits must be parseable per
         // https://datatracker.ietf.org/doc/html/rfc7234#section-1.2.1.
         // Parsers may allow higher numbers.
-        preceded(tag_no_case("s-maxage="),
-                 map(map_res(parameter_value, |s| s.parse::<u32>()),
-                     |i| Directive::SMaxAge(Duration::from_secs(i.into())))),
-        preceded(tag_no_case("max-age="),
-                 map(map_res(parameter_value, |s| s.parse::<u32>()),
-                     |i| Directive::MaxAge(Duration::from_secs(i.into())))),
-        map(pair(token, opt(pair(char('='), parameter_value))), |_| Directive::Other),
+        preceded(
+            tag_no_case("s-maxage="),
+            map(map_res(parameter_value, |s| s.parse::<u32>()), |i| {
+                Directive::SMaxAge(Duration::from_secs(i.into()))
+            }),
+        ),
+        preceded(
+            tag_no_case("max-age="),
+            map(map_res(parameter_value, |s| s.parse::<u32>()), |i| {
+                Directive::MaxAge(Duration::from_secs(i.into()))
+            }),
+        ),
+        map(pair(token, opt(pair(char('='), parameter_value))), |_| {
+            Directive::Other
+        }),
     ))(input)
 }
 
@@ -67,8 +65,12 @@ pub fn freshness_lifetime(directives: Vec<Directive>) -> Option<Duration> {
     let mut max_age = None::<Duration>;
     for directive in directives {
         match directive {
-            Directive::SMaxAge(duration) => { s_maxage.get_or_insert(duration); },
-            Directive::MaxAge(duration) => { max_age.get_or_insert(duration); },
+            Directive::SMaxAge(duration) => {
+                s_maxage.get_or_insert(duration);
+            }
+            Directive::MaxAge(duration) => {
+                max_age.get_or_insert(duration);
+            }
             Directive::Other => (),
         };
     }
@@ -80,38 +82,92 @@ mod tests {
     use super::*;
     #[test]
     fn directive_s_maxage() {
-        assert_eq!(directive("s-maxage=3600").unwrap(), ("", Directive::SMaxAge(Duration::from_secs(3600))));
-        assert_eq!(directive("s-maxage=\"3600\"").unwrap(), ("", Directive::SMaxAge(Duration::from_secs(3600))));
+        assert_eq!(
+            directive("s-maxage=3600").unwrap(),
+            ("", Directive::SMaxAge(Duration::from_secs(3600)))
+        );
+        assert_eq!(
+            directive("s-maxage=\"3600\"").unwrap(),
+            ("", Directive::SMaxAge(Duration::from_secs(3600)))
+        );
         assert_eq!(directive("s-maxage=-1").unwrap(), ("", Directive::Other));
         assert_eq!(directive("s-maxage=1e6").unwrap(), ("", Directive::Other));
-        assert_eq!(directive("s-maxage=\"3600").unwrap_err().to_string(), "Parsing requires more data");
+        assert_eq!(
+            directive("s-maxage=\"3600").unwrap_err().to_string(),
+            "Parsing requires more data"
+        );
     }
     #[test]
     fn directive_max_age() {
-        assert_eq!(directive("max-age=3600").unwrap(), ("", Directive::MaxAge(Duration::from_secs(3600))));
-        assert_eq!(directive("max-age=\"3600\"").unwrap(), ("", Directive::MaxAge(Duration::from_secs(3600))));
+        assert_eq!(
+            directive("max-age=3600").unwrap(),
+            ("", Directive::MaxAge(Duration::from_secs(3600)))
+        );
+        assert_eq!(
+            directive("max-age=\"3600\"").unwrap(),
+            ("", Directive::MaxAge(Duration::from_secs(3600)))
+        );
         assert_eq!(directive("max-age=-1").unwrap(), ("", Directive::Other));
         assert_eq!(directive("max-age=1e6").unwrap(), ("", Directive::Other));
-        assert_eq!(directive("max-age=\"3600").unwrap_err().to_string(), "Parsing requires more data");
+        assert_eq!(
+            directive("max-age=\"3600").unwrap_err().to_string(),
+            "Parsing requires more data"
+        );
     }
     #[test]
     fn directive_other() {
         assert_eq!(directive("no-store").unwrap(), ("", Directive::Other));
-        assert_eq!(directive("no-cache=set-cookie").unwrap(), ("", Directive::Other));
-        assert_eq!(directive("no-cache=\"set-cookie, set-cookie2\"").unwrap(), ("", Directive::Other));
-        assert_eq!(directive("no-cache=\"set-cookie").unwrap_err().to_string(), "Parsing requires more data");
+        assert_eq!(
+            directive("no-cache=set-cookie").unwrap(),
+            ("", Directive::Other)
+        );
+        assert_eq!(
+            directive("no-cache=\"set-cookie, set-cookie2\"").unwrap(),
+            ("", Directive::Other)
+        );
+        assert_eq!(
+            directive("no-cache=\"set-cookie").unwrap_err().to_string(),
+            "Parsing requires more data"
+        );
     }
     #[test]
     fn directive_multiple() {
-        assert_eq!(directive("no-cache=\"set-cookie, set-cookie2\", no-store").unwrap(), (", no-store", Directive::Other));
+        assert_eq!(
+            directive("no-cache=\"set-cookie, set-cookie2\", no-store").unwrap(),
+            (", no-store", Directive::Other)
+        );
     }
     #[test]
     fn freshness_lifetimes() {
         assert_eq!(freshness_lifetime(vec![]), None);
-        assert_eq!(freshness_lifetime(vec![Directive::SMaxAge(Duration::from_secs(3600))]), Some(Duration::from_secs(3600)));
-        assert_eq!(freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(3600))]), Some(Duration::from_secs(3600)));
-        assert_eq!(freshness_lifetime(vec![Directive::SMaxAge(Duration::from_secs(3600)), Directive::MaxAge(Duration::from_secs(200))]), Some(Duration::from_secs(3600)));
-        assert_eq!(freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(200)), Directive::SMaxAge(Duration::from_secs(3600))]), Some(Duration::from_secs(3600)));
-        assert_eq!(freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(3600)), Directive::MaxAge(Duration::from_secs(200))]), Some(Duration::from_secs(3600)));
+        assert_eq!(
+            freshness_lifetime(vec![Directive::SMaxAge(Duration::from_secs(3600))]),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(
+            freshness_lifetime(vec![Directive::MaxAge(Duration::from_secs(3600))]),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(
+            freshness_lifetime(vec![
+                Directive::SMaxAge(Duration::from_secs(3600)),
+                Directive::MaxAge(Duration::from_secs(200))
+            ]),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(
+            freshness_lifetime(vec![
+                Directive::MaxAge(Duration::from_secs(200)),
+                Directive::SMaxAge(Duration::from_secs(3600))
+            ]),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(
+            freshness_lifetime(vec![
+                Directive::MaxAge(Duration::from_secs(3600)),
+                Directive::MaxAge(Duration::from_secs(200))
+            ]),
+            Some(Duration::from_secs(3600))
+        );
     }
 }

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -12,20 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::base::{is_quoted_pair_payload, is_tchar, ows, parameter_value, token};
 use nom::{
-    IResult,
     bytes::complete::take_while,
     character::complete::char,
     combinator::{map, opt},
     multi::many0,
     sequence::{delimited, pair, preceded, terminated, tuple},
-};
-use super::base::{
-    is_quoted_pair_payload,
-    is_tchar,
-    ows,
-    parameter_value,
-    token,
+    IResult,
 };
 
 // Represents an individual link directive i.e. an instance of `link-value`
@@ -42,28 +36,41 @@ fn quote(value: &str) -> Option<String> {
     if value.chars().all(|c| is_tchar(c)) {
         Some(value.into())
     } else if value.chars().all(|c| is_quoted_pair_payload(c)) {
-        Some("\"".to_string() + &value.chars().map(|c: char| {
-            if c == '\\' || c == '"' {
-                format!("\\{}", c)
-            } else {
-                format!("{}", c)
-            }
-        }).collect::<String>() + "\"")
+        Some(
+            "\"".to_string()
+                + &value
+                    .chars()
+                    .map(|c: char| {
+                        if c == '\\' || c == '"' {
+                            format!("\\{}", c)
+                        } else {
+                            format!("{}", c)
+                        }
+                    })
+                    .collect::<String>()
+                + "\"",
+        )
     } else {
         None
     }
 }
 
-impl <'a> Link<'a> {
+impl<'a> Link<'a> {
     pub fn serialize(&self) -> String {
-        "<".to_string() + self.uri + ">" +
-            &self.params.iter().filter_map(|(k, v)| {
-                Some(if let Some(v) = v {
-                    format!(";{}={}", k, quote(v)?)
-                } else {
-                    format!(";{}", k)
+        "<".to_string()
+            + self.uri
+            + ">"
+            + &self
+                .params
+                .iter()
+                .filter_map(|(k, v)| {
+                    Some(if let Some(v) = v {
+                        format!(";{}={}", k, quote(v)?)
+                    } else {
+                        format!(";{}", k)
+                    })
                 })
-            }).collect::<String>()
+                .collect::<String>()
     }
 }
 
@@ -73,32 +80,35 @@ fn uri_ref(input: &str) -> IResult<&str, &str> {
     // URL class for parsing and validation. For defense in depth, we only allow
     // the characters specified in
     // https://datatracker.ietf.org/doc/html/rfc3986#appendix-A.
-    take_while(|c: char|
-        match c {
-            // unreserved
-            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' => true,
-            // gen-delims
-            ':' | '|' | '?' | '#' | '[' | ']' | '@' => true,
-            // sub-delims
-            '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' => true,
-            // pct-encoded
-            '%' => true,
-            // path
-            '/' => true,
-            _ => false,
-        }
-    )(input)
+    take_while(|c: char| match c {
+        // unreserved
+        'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' => true,
+        // gen-delims
+        ':' | '|' | '?' | '#' | '[' | ']' | '@' => true,
+        // sub-delims
+        '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' => true,
+        // pct-encoded
+        '%' => true,
+        // path
+        '/' => true,
+        _ => false,
+    })(input)
 }
 
 fn link_param<'a>(input: &'a str) -> IResult<&str, (&'a str, Option<String>)> {
-    pair(terminated(token, ows),
-         opt(preceded(pair(char('='), ows), parameter_value)))(input)
+    pair(
+        terminated(token, ows),
+        opt(preceded(pair(char('='), ows), parameter_value)),
+    )(input)
 }
 
 pub fn link(input: &str) -> IResult<&str, Link> {
-    map(pair(delimited(char('<'), uri_ref, char('>')),
-             many0(preceded(tuple((ows, char(';'), ows)), link_param))), |(uri, params)|
-        Link{uri, params}
+    map(
+        pair(
+            delimited(char('<'), uri_ref, char('>')),
+            many0(preceded(tuple((ows, char(';'), ows)), link_param)),
+        ),
+        |(uri, params)| Link { uri, params },
     )(input)
 }
 
@@ -107,27 +117,92 @@ mod tests {
     use super::*;
     #[test]
     fn parse() {
-        assert_eq!(link("<>").unwrap(), ("", Link{uri: "", params: vec![]}));
-        assert_eq!(link("</foo,bar;baz>").unwrap(), ("", Link{uri: "/foo,bar;baz", params: vec![]}));
-        assert_eq!(link("</foo>;bar;baz=quux").unwrap(),
-                   ("", Link{uri: "/foo",
-                             params: vec![("bar", None), ("baz", Some("quux".into()))]}));
-        assert_eq!(link(r#"</foo>;bar="baz \\\"quux""#).unwrap(),
-                   ("", Link{uri: "/foo",
-                             params: vec![("bar", Some(r#"baz \"quux"#.into()))]}));
-        assert!(matches!(link(r#"</foo>;bar="baz \""#).unwrap_err(), nom::Err::Incomplete(_)));
+        assert_eq!(
+            link("<>").unwrap(),
+            (
+                "",
+                Link {
+                    uri: "",
+                    params: vec![]
+                }
+            )
+        );
+        assert_eq!(
+            link("</foo,bar;baz>").unwrap(),
+            (
+                "",
+                Link {
+                    uri: "/foo,bar;baz",
+                    params: vec![]
+                }
+            )
+        );
+        assert_eq!(
+            link("</foo>;bar;baz=quux").unwrap(),
+            (
+                "",
+                Link {
+                    uri: "/foo",
+                    params: vec![("bar", None), ("baz", Some("quux".into()))]
+                }
+            )
+        );
+        assert_eq!(
+            link(r#"</foo>;bar="baz \\\"quux""#).unwrap(),
+            (
+                "",
+                Link {
+                    uri: "/foo",
+                    params: vec![("bar", Some(r#"baz \"quux"#.into()))]
+                }
+            )
+        );
+        assert!(matches!(
+            link(r#"</foo>;bar="baz \""#).unwrap_err(),
+            nom::Err::Incomplete(_)
+        ));
     }
     #[test]
     fn serialize() {
-        assert_eq!(Link{uri: "/foo", params: vec![("bar", None)]}.serialize(),
-                   "</foo>;bar");
-        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some("baz".into()))]}.serialize(),
-                   "</foo>;bar=baz");
-        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some("baz quux".into()))]}.serialize(),
-                   r#"</foo>;bar="baz quux""#);
-        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some(r#"baz\"quux"#.into()))]}.serialize(),
-                   r#"</foo>;bar="baz\\\"quux""#);
-        assert_eq!(Link{uri: "/foo", params: vec![("bar", Some("\x7f".into()))]}.serialize(),
-                   "</foo>");
+        assert_eq!(
+            Link {
+                uri: "/foo",
+                params: vec![("bar", None)]
+            }
+            .serialize(),
+            "</foo>;bar"
+        );
+        assert_eq!(
+            Link {
+                uri: "/foo",
+                params: vec![("bar", Some("baz".into()))]
+            }
+            .serialize(),
+            "</foo>;bar=baz"
+        );
+        assert_eq!(
+            Link {
+                uri: "/foo",
+                params: vec![("bar", Some("baz quux".into()))]
+            }
+            .serialize(),
+            r#"</foo>;bar="baz quux""#
+        );
+        assert_eq!(
+            Link {
+                uri: "/foo",
+                params: vec![("bar", Some(r#"baz\"quux"#.into()))]
+            }
+            .serialize(),
+            r#"</foo>;bar="baz\\\"quux""#
+        );
+        assert_eq!(
+            Link {
+                uri: "/foo",
+                params: vec![("bar", Some("\x7f".into()))]
+            }
+            .serialize(),
+            "</foo>"
+        );
     }
 }

--- a/sxg_rs/src/http_parser/media_type.rs
+++ b/sxg_rs/src/http_parser/media_type.rs
@@ -12,20 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nom::{
-    character::complete::char as char1,
-    many0,
-    map,
-    named,
-    preceded,
-    separated_pair,
-    tuple,
-};
-use super::base::{
-    ows,
-    parameter_value,
-    token,
-};
+use super::base::{ows, parameter_value, token};
+use nom::{character::complete::char as char1, many0, map, named, preceded, separated_pair, tuple};
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct MediaType<'a> {
@@ -87,12 +75,10 @@ mod tests {
                 MediaType {
                     primary_type: "text",
                     sub_type: "html",
-                    parameters: vec![
-                        Parameter {
-                            name: "charset",
-                            value: "utf-8".to_string(),
-                        }
-                    ],
+                    parameters: vec![Parameter {
+                        name: "charset",
+                        value: "utf-8".to_string(),
+                    }],
                 }
             )
         );
@@ -126,12 +112,10 @@ mod tests {
                 MediaType {
                     primary_type: "a",
                     sub_type: "b",
-                    parameters: vec![
-                        Parameter {
-                            name: "x",
-                            value: "1".to_string(),
-                        }
-                    ],
+                    parameters: vec![Parameter {
+                        name: "x",
+                        value: "1".to_string(),
+                    }],
                 }
             )
         );
@@ -145,12 +129,10 @@ mod tests {
                 MediaType {
                     primary_type: "a",
                     sub_type: "b",
-                    parameters: vec![
-                        Parameter {
-                            name: "x",
-                            value: "1".to_string(),
-                        }
-                    ],
+                    parameters: vec![Parameter {
+                        name: "x",
+                        value: "1".to_string(),
+                    }],
                 }
             )
         );
@@ -203,8 +185,6 @@ mod tests {
     }
     #[test]
     fn unclosed_quoted_string() {
-        assert!(
-            media_type(r#"a/b;x="1\"23;y=0"#).is_err()
-        )
+        assert!(media_type(r#"a/b;x="1\"23;y=0"#).is_err())
     }
 }

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -15,19 +15,15 @@
 mod accept;
 mod base;
 mod cache_control;
-pub mod media_type;
 pub mod link;
+pub mod media_type;
 
 use anyhow::{Error, Result};
-use nom::{
-    IResult,
-    character::complete::char as char1,
-    combinator::complete,
-    eof,
-    separated_list0,
-    separated_pair,
-};
 use base::ows;
+use nom::{
+    character::complete::char as char1, combinator::complete, eof, separated_list0, separated_pair,
+    IResult,
+};
 use std::time::Duration;
 
 fn format_nom_err(err: nom::Err<nom::error::Error<&str>>) -> Error {
@@ -37,13 +33,11 @@ fn format_nom_err(err: nom::Err<nom::error::Error<&str>>) -> Error {
 // Parses a http header which might have multiple values separated by comma.
 fn parse_vec<'a, F, T>(input: &'a str, parse_single: F) -> Result<Vec<T>>
 where
-    F: Fn(&'a str) -> IResult<&'a str, T>
+    F: Fn(&'a str) -> IResult<&'a str, T>,
 {
-    let (input, items) = separated_list0!(
-        input,
-        separated_pair!(ows, char1(','), ows),
-        parse_single
-    ).map_err(format_nom_err)?;
+    let (input, items) =
+        separated_list0!(input, separated_pair!(ows, char1(','), ows), parse_single)
+            .map_err(format_nom_err)?;
     eof!(input,).map_err(format_nom_err)?;
     Ok(items)
 }
@@ -55,7 +49,8 @@ pub fn parse_accept_header(input: &str) -> Result<Vec<accept::Accept>> {
 // Returns the freshness lifetime for a shared cache.
 pub fn parse_cache_control_header(input: &str) -> Result<Duration> {
     let directives = parse_vec(input, cache_control::directive)?;
-    cache_control::freshness_lifetime(directives).ok_or(Error::msg("Freshness lifetime is implicit"))
+    cache_control::freshness_lifetime(directives)
+        .ok_or(Error::msg("Freshness lifetime is implicit"))
 }
 
 pub fn parse_content_type_header(input: &str) -> Result<media_type::MediaType> {

--- a/sxg_rs/src/id_headers.rs
+++ b/sxg_rs/src/id_headers.rs
@@ -1,12 +1,12 @@
-use std::collections::HashSet;
 use once_cell::sync::Lazy;
+use std::collections::HashSet;
 
 // The full list of id headers is adds about 37K to the binary, as of writing,
 // so users may choose to exclude it.
-#[cfg(not(feature="strip_id_headers"))]
+#[cfg(not(feature = "strip_id_headers"))]
 pub static ID_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| HashSet::new());
 
-#[cfg(feature="strip_id_headers")]
+#[cfg(feature = "strip_id_headers")]
 pub static ID_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     vec![
         // These headers are nonstandard, and don't affect browser behavior at
@@ -1158,5 +1158,7 @@ pub static ID_HEADERS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         r#"y-who"#,
         r#"yjs-cachestatus"#,
         r#"yjs-id"#,
-    ].into_iter().collect()
+    ]
+    .into_iter()
+    .collect()
 });

--- a/sxg_rs/src/mice.rs
+++ b/sxg_rs/src/mice.rs
@@ -14,15 +14,12 @@
 
 // https://tools.ietf.org/html/draft-thomson-http-mice-03
 
+use ::sha2::{Digest, Sha256};
 use std::collections::VecDeque;
-use ::sha2::{Sha256, Digest};
 
 pub fn calculate(input: &[u8], record_size: usize) -> (Vec<u8>, Vec<u8>) {
     if input.len() == 0 {
-        return (
-            crate::utils::get_sha(&[0]),
-            vec![],
-        );
+        return (crate::utils::get_sha(&[0]), vec![]);
     }
     let record_size = std::cmp::min(record_size, input.len());
     let records: Vec<_> = if record_size > 0 {
@@ -80,7 +77,8 @@ mod tests {
                     &input[16..32],
                     &::base64::decode("iPMpmgExHPrbEX3/RvwP4d16fWlK4l++p75PUu/KyN0=").unwrap(),
                     &input[32..],
-                ].concat(),
+                ]
+                .concat(),
             ),
         );
     }

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature="js_signer")]
+#[cfg(feature = "js_signer")]
 pub mod js_signer;
-#[cfg(feature="rust_signer")]
+#[cfg(feature = "rust_signer")]
 pub mod rust_signer;
 
+use crate::structured_header::{ParamItem, ShItem, ShParamList};
 use anyhow::Result;
 use async_trait::async_trait;
-use crate::structured_header::{ShItem, ShParamList, ParamItem};
 
 #[async_trait(?Send)]
 pub trait Signer {
@@ -80,8 +80,12 @@ impl<'a> Signature<'a> {
             request_url.as_bytes(),
             &(headers.len() as u64).to_be_bytes(),
             &headers,
-        ].concat();
-        let sig = signer.sign(&message).await.map_err(|e| e.context("Failed to sign the message."))?;
+        ]
+        .concat();
+        let sig = signer
+            .sign(&message)
+            .await
+            .map_err(|e| e.context("Failed to sign the message."))?;
         Ok(Signature {
             cert_url,
             cert_sha256,

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::Signer;
 use anyhow::Result;
 use async_trait::async_trait;
 use p256::ecdsa::SigningKey;
-use super::Signer;
 
 pub struct RustSigner {
     private_key: SigningKey,

--- a/sxg_rs/src/structured_header/item.rs
+++ b/sxg_rs/src/structured_header/item.rs
@@ -27,7 +27,7 @@ impl<'a> fmt::Display for ShItem<'a> {
         match self {
             ShItem::ByteSequence(bytes) => {
                 write!(f, "*{}*", ::base64::encode(bytes))
-            },
+            }
             ShItem::Integer(x) => write!(f, "{}", x),
             ShItem::String(x) => {
                 write!(f, "\"")?;
@@ -35,18 +35,17 @@ impl<'a> fmt::Display for ShItem<'a> {
                     match c {
                         '\\' | '\"' => {
                             write!(f, "\\{}", c)?;
-                        },
+                        }
                         '\u{20}'..='\u{21}' | '\u{23}'..='\u{5b}' | '\u{5d}'..='\u{7e}' => {
                             write!(f, "{}", c)?;
-                        },
+                        }
                         '\u{0}'..='\u{1f}' | '\u{7f}'..='\u{10ffff}' => {
                             return Err(std::fmt::Error);
-                        },
+                        }
                     };
                 }
                 write!(f, "\"")
-            },
+            }
         }
     }
 }
-

--- a/sxg_rs/src/structured_header/mod.rs
+++ b/sxg_rs/src/structured_header/mod.rs
@@ -19,4 +19,3 @@ mod parameterised_list;
 
 pub use item::ShItem;
 pub use parameterised_list::{ParamItem, ShParamList};
-

--- a/sxg_rs/src/structured_header/parameterised_list.rs
+++ b/sxg_rs/src/structured_header/parameterised_list.rs
@@ -84,4 +84,3 @@ impl<'a> fmt::Display for ShParamList<'a> {
         Ok(())
     }
 }
-

--- a/sxg_rs/src/sxg.rs
+++ b/sxg_rs/src/sxg.rs
@@ -15,17 +15,28 @@
 use anyhow::{Error, Result};
 
 // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#application-signed-exchange
-pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payload_body: &[u8]) -> Result<Vec<u8>> {
+pub fn build(
+    fallback_url: &str,
+    signature: &[u8],
+    signed_headers: &[u8],
+    payload_body: &[u8],
+) -> Result<Vec<u8>> {
     // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#name-application-signed-exchange
     const SIG_LEN_LIMIT: usize = 16384;
     let sig_len = signature.len();
     if sig_len > SIG_LEN_LIMIT {
-        return Err(Error::msg(format!("sigLength {} is and larger than the limit {}", sig_len, SIG_LEN_LIMIT)));
+        return Err(Error::msg(format!(
+            "sigLength {} is and larger than the limit {}",
+            sig_len, SIG_LEN_LIMIT
+        )));
     }
     const HEADER_LEN_LIMIT: usize = 524288;
     let header_len = signed_headers.len();
     if header_len > HEADER_LEN_LIMIT {
-        return Err(Error::msg(format!("headerLength {} is larger than the limit {}", header_len, HEADER_LEN_LIMIT)));
+        return Err(Error::msg(format!(
+            "headerLength {} is larger than the limit {}",
+            header_len, HEADER_LEN_LIMIT
+        )));
     }
     Ok([
         "sxg1-b3\0".as_bytes(),
@@ -36,6 +47,6 @@ pub fn build(fallback_url: &str, signature: &[u8], signed_headers: &[u8], payloa
         signature,
         signed_headers,
         payload_body,
-    ].concat())
+    ]
+    .concat())
 }
-

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 pub fn get_sha(bytes: &[u8]) -> Vec<u8> {
-    use ::sha2::{Sha256, Digest};
+    use ::sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     hasher.finalize().to_vec()


### PR DESCRIPTION
- Create `rustfmt.toml` to use [rustfmt](https://github.com/rust-lang/rustfmt).
- Add `.github/workflows/code-style.yml` to check Rust format in GitHub actions.
- Fix `.github/workflows/unit-tests.yml` with license header.
- Use `cargo fmt` to format all Rust files `**/*.rs`.

Fix #50 