### PR TITLE
Remove uses of Box and dyn.

### DIFF
--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -100,9 +100,7 @@ pub async fn create_signed_exchange(
         payload_headers.into_serde().unwrap(),
         &get_worker()?.config.strip_response_headers,
     );
-    let signer = ::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(
-        signer,
-    );
+    let signer = ::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(signer);
     let sxg: HttpResponse = get_worker()?
         .create_signed_exchange(::sxg_rs::CreateSignedExchangeParams {
             fallback_url: &fallback_url,

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -45,7 +45,7 @@ pub fn get_last_error_message() -> JsValue {
 
 #[wasm_bindgen(js_name=fetchOcspFromCa)]
 pub async fn fetch_ocsp_from_ca(fetcher: Function) -> Result<Uint8Array, JsValue> {
-    let fetcher = Box::new(sxg_rs::fetcher::js_fetcher::JsFetcher::new(fetcher));
+    let fetcher = sxg_rs::fetcher::js_fetcher::JsFetcher::new(fetcher);
     let request = get_worker()?.fetch_ocsp_from_ca(fetcher).await;
     Ok(Uint8Array::from(request.as_slice()))
 }
@@ -100,9 +100,9 @@ pub async fn create_signed_exchange(
         payload_headers.into_serde().unwrap(),
         &get_worker()?.config.strip_response_headers,
     );
-    let signer = Box::new(::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(
+    let signer = ::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(
         signer,
-    ));
+    );
     let sxg: HttpResponse = get_worker()?
         .create_signed_exchange(::sxg_rs::CreateSignedExchangeParams {
             fallback_url: &fallback_url,

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -101,9 +101,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
             .as_ref()
             .ok_or(Error::msg("private_key_base64 is not set"))?,
     )?;
-    let signer = ::sxg_rs::signature::rust_signer::RustSigner::new(
-        &private_key_der,
-    );
+    let signer = ::sxg_rs::signature::rust_signer::RustSigner::new(&private_key_der);
     let payload_headers = get_rsp_header_fields(&payload)?;
     payload_headers.validate_as_sxg_payload()?;
     let payload_body = payload.into_body_bytes();

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -101,9 +101,9 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
             .as_ref()
             .ok_or(Error::msg("private_key_base64 is not set"))?,
     )?;
-    let signer = Box::new(::sxg_rs::signature::rust_signer::RustSigner::new(
+    let signer = ::sxg_rs::signature::rust_signer::RustSigner::new(
         &private_key_der,
-    ));
+    );
     let payload_headers = get_rsp_header_fields(&payload)?;
     payload_headers.validate_as_sxg_payload()?;
     let payload_body = payload.into_body_bytes();
@@ -122,7 +122,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
 }
 
 fn handle_request(req: Request) -> Result<Response> {
-    let fetcher = Box::new(FastlyFetcher::new("OCSP server"));
+    let fetcher = FastlyFetcher::new("OCSP server");
     // TODO: store OCSP in database
     let ocsp_der = WORKER.fetch_ocsp_from_ca(fetcher);
     let ocsp_der = block_on(ocsp_der);

--- a/sxg_rs/src/ocsp/mod.rs
+++ b/sxg_rs/src/ocsp/mod.rs
@@ -93,10 +93,10 @@ const AIA: Oid<'static> = oid!(1.3.6 .1 .5 .5 .7 .1 .1);
 // https://www.iana.org/assignments/smi-numbers/smi-numbers.xhtml#smi-numbers-1.3.6.1.5.5.7.48.1
 const AIA_OCSP: Oid<'static> = oid!(1.3.6 .1 .5 .5 .7 .48 .1);
 
-pub async fn fetch_from_ca<'a>(
+pub async fn fetch_from_ca<'a, F: Fetcher>(
     cert_der: &'a [u8],
     issuer_der: &'a [u8],
-    fetcher: Box<dyn Fetcher>,
+    fetcher: F,
 ) -> Vec<u8> {
     let cert = x509_parser::parse_x509_certificate(&cert_der).unwrap().1;
     let issuer = x509_parser::parse_x509_certificate(&issuer_der).unwrap().1;

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -27,7 +27,7 @@ pub trait Signer {
     async fn sign(&self, message: &[u8]) -> Result<Vec<u8>>;
 }
 
-pub struct SignatureParams<'a> {
+pub struct SignatureParams<'a, S: Signer> {
     pub cert_url: &'a str,
     pub cert_sha256: &'a [u8],
     pub date: std::time::SystemTime,
@@ -35,7 +35,7 @@ pub struct SignatureParams<'a> {
     pub headers: &'a [u8],
     pub id: &'a str,
     pub request_url: &'a str,
-    pub signer: Box<dyn Signer>,
+    pub signer: S,
     pub validity_url: &'a str,
 }
 
@@ -51,7 +51,7 @@ pub struct Signature<'a> {
 }
 
 impl<'a> Signature<'a> {
-    pub async fn new(params: SignatureParams<'a>) -> Result<Signature<'a>> {
+    pub async fn new<S: Signer>(params: SignatureParams<'a, S>) -> Result<Signature<'a>> {
         let SignatureParams {
             cert_url,
             cert_sha256,


### PR DESCRIPTION
This simplifies the type a bit, and maybe speeds it up a bit by saving a
virtual method call. I don't think it reduces flexibility, since Signer and
Fetcher are not persisted in SxgWorker, but rather passed to the relevant
methods on each request.