### PR TITLE
Set worker config to be a private field

### DIFF
--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -19,7 +19,7 @@ use once_cell::sync::OnceCell;
 use sxg_rs::headers::AcceptFilter;
 use sxg_rs::http::HttpResponse;
 use sxg_rs::SxgWorker;
-use utils::anything_to_js_error;
+use utils::to_js_error;
 use wasm_bindgen::prelude::*;
 
 static WORKER: OnceCell<SxgWorker> = OnceCell::new();
@@ -75,7 +75,7 @@ pub fn create_request_headers(
     let result = get_worker()?.transform_request_headers(fields, accept_filter);
     match result {
         Ok(fields) => Ok(JsValue::from_serde(&fields).unwrap()),
-        Err(err) => Err(anything_to_js_error(err)),
+        Err(err) => Err(to_js_error(err)),
     }
 }
 
@@ -84,7 +84,7 @@ pub fn validate_payload_headers(fields: JsValue) -> Result<(), JsValue> {
     let fields = fields.into_serde().unwrap();
     get_worker()?
         .transform_payload_headers(fields)
-        .map_err(anything_to_js_error)?;
+        .map_err(to_js_error)?;
     Ok(())
 }
 
@@ -98,10 +98,10 @@ pub async fn create_signed_exchange(
     now_in_seconds: u32,
     signer: Function,
 ) -> Result<JsValue, JsValue> {
-    let payload_headers = payload_headers.into_serde().map_err(anything_to_js_error)?;
+    let payload_headers = payload_headers.into_serde().map_err(to_js_error)?;
     let payload_headers = get_worker()?
         .transform_payload_headers(payload_headers)
-        .map_err(anything_to_js_error)?;
+        .map_err(to_js_error)?;
     let signer = ::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(signer);
     let sxg: HttpResponse = get_worker()?
         .create_signed_exchange(::sxg_rs::CreateSignedExchangeParams {
@@ -114,6 +114,6 @@ pub async fn create_signed_exchange(
             status_code,
         })
         .await
-        .map_err(anything_to_js_error)?;
+        .map_err(to_js_error)?;
     Ok(JsValue::from_serde(&sxg).unwrap())
 }

--- a/cloudflare_worker/src/utils.rs
+++ b/cloudflare_worker/src/utils.rs
@@ -43,6 +43,6 @@ pub fn get_last_error_message() -> JsValue {
     }
 }
 
-pub fn anything_to_js_error<T: std::fmt::Debug>(error: T) -> JsValue {
+pub fn to_js_error<T: std::fmt::Debug>(error: T) -> JsValue {
     JsValue::from_str(&format!("{:?}", error))
 }

--- a/cloudflare_worker/src/utils.rs
+++ b/cloudflare_worker/src/utils.rs
@@ -43,6 +43,6 @@ pub fn get_last_error_message() -> JsValue {
     }
 }
 
-pub fn anyhow_error_to_js_value(error: anyhow::Error) -> JsValue {
+pub fn anything_to_js_error<T: std::fmt::Debug>(error: T) -> JsValue {
     JsValue::from_str(&format!("{:?}", error))
 }

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -46,7 +46,7 @@ const USER_AGENT: &str = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB2
 const SEVEN_DAYS: Duration = Duration::from_secs(60 * 60 * 24 * 7);
 
 impl Headers {
-    pub fn new(data: HeaderFields, strip_headers: &BTreeSet<String>) -> Self {
+    pub(crate) fn new(data: HeaderFields, strip_headers: &BTreeSet<String>) -> Self {
         let mut headers = Headers(HashMap::new());
         for (mut k, v) in data {
             k.make_ascii_lowercase();
@@ -56,7 +56,7 @@ impl Headers {
         }
         headers
     }
-    pub fn forward_to_origin_server(
+    pub(crate) fn forward_to_origin_server(
         self,
         accept_filter: AcceptFilter,
         forwarded_header_names: &BTreeSet<String>,
@@ -100,7 +100,7 @@ impl Headers {
         }
         Ok(new_headers.into_iter().collect())
     }
-    pub fn validate_as_sxg_payload(&self) -> Result<()> {
+    pub(crate) fn validate_as_sxg_payload(&self) -> Result<()> {
         for (k, v) in self.0.iter() {
             if DONT_SIGN_RESPONSE_HEADERS.contains(k.as_str()) {
                 return Err(Error::msg(format!(
@@ -246,7 +246,7 @@ impl Headers {
         fields.push(("digest", &digest));
         serializer(fields)
     }
-    pub fn get_signed_headers_bytes(
+    pub(crate) fn get_signed_headers_bytes(
         &self,
         fallback_url: &Url,
         status_code: u16,
@@ -284,7 +284,7 @@ impl Headers {
         }
     }
     // How long the signature should last, or error if the response shouldn't be signed.
-    pub fn signature_duration(&self) -> Result<Duration> {
+    pub(crate) fn signature_duration(&self) -> Result<Duration> {
         // Default to 7 days unless a cache-control directive lowers it.
         if let Some(value) = self.0.get("cache-control") {
             if let Ok(duration) = parse_cache_control_header(value) {

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -264,15 +264,8 @@ impl SxgWorker {
                 .as_ref()
                 .ok_or(Error::msg("Config private_key_base64 is not set"))?,
         )?;
-        const KEY_SIZE: usize = 32;
-        if private_key_der.len() != KEY_SIZE {
-            return Err(Error::msg(format!(
-                "Expecting byte size of private_key_base64 to be {}, found {}",
-                KEY_SIZE,
-                private_key_der.len()
-            )));
-        }
-        Ok(signature::rust_signer::RustSigner::new(&private_key_der))
+        signature::rust_signer::RustSigner::new(&private_key_der)
+            .map_err(|e| e.context("Failed to call RustSigner::new()."))
     }
     pub fn should_respond_debug_info(&self) -> bool {
         self.config.respond_debug_info

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -34,7 +34,7 @@ use serde::Serialize;
 use url::Url;
 
 pub struct SxgWorker {
-    pub config: Config,
+    config: Config,
 }
 
 #[derive(Serialize, Debug, PartialEq)]
@@ -239,6 +239,8 @@ impl SxgWorker {
             None
         }
     }
+    /// Checks `fields` as request headers from browser,
+    /// and returns the request headers to be sent to backend server.
     pub fn transform_request_headers(
         &self,
         fields: HeaderFields,
@@ -247,9 +249,46 @@ impl SxgWorker {
         let headers = Headers::new(fields, &self.config.strip_request_headers);
         headers.forward_to_origin_server(accept_filter, &self.config.forward_request_headers)
     }
-    pub fn validate_payload_headers(&self, fields: HeaderFields) -> Result<()> {
+    /// Checks `fields` as response headers from backend server,
+    /// and returns the reqsponse headers to be sent to browser.
+    pub fn transform_payload_headers(&self, fields: HeaderFields) -> Result<Headers> {
         let headers = Headers::new(fields, &self.config.strip_response_headers);
-        headers.validate_as_sxg_payload()
+        headers.validate_as_sxg_payload()?;
+        Ok(headers)
+    }
+    #[cfg(feature = "rust_signer")]
+    pub fn create_rust_signer(&self) -> Result<signature::rust_signer::RustSigner> {
+        let private_key_der = base64::decode(
+            self.config
+                .private_key_base64
+                .as_ref()
+                .ok_or(Error::msg("Config private_key_base64 is not set"))?,
+        )?;
+        const KEY_SIZE: usize = 32;
+        if private_key_der.len() != KEY_SIZE {
+            return Err(Error::msg(format!(
+                "Expecting byte size of private_key_base64 to be {}, found {}",
+                KEY_SIZE,
+                private_key_der.len()
+            )));
+        }
+        Ok(signature::rust_signer::RustSigner::new(&private_key_der))
+    }
+    pub fn should_respond_debug_info(&self) -> bool {
+        self.config.respond_debug_info
+    }
+    /// Replaces the host name to be the html_host in the config.
+    // TODO: implement get_fallback_url_and_cert_origin, so that Cloudflare Worker can use it.
+    pub fn get_fallback_url(&self, original_url: &Url) -> Result<Url> {
+        let mut fallback = original_url.clone();
+        if let Some(html_host) = &self.config.html_host {
+            if !html_host.is_empty() {
+                fallback
+                    .set_host(Some(&html_host))
+                    .map_err(|e| Error::new(e))?;
+            }
+        }
+        Ok(fallback)
     }
 }
 

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -22,9 +22,9 @@ pub struct RustSigner {
 }
 
 impl RustSigner {
-    pub fn new(private_key: &[u8]) -> Self {
-        let private_key = SigningKey::from_bytes(private_key).unwrap();
-        RustSigner { private_key }
+    pub fn new(private_key: &[u8]) -> Result<Self> {
+        let private_key = SigningKey::from_bytes(private_key)?;
+        Ok(RustSigner { private_key })
     }
 }
 


### PR DESCRIPTION
- Set `config` to be a private member of struct `SxgConfig`.

- Add a few public member functions to struct `SxgWorker`, so that `cloudflare_worker/*` and `fastly_compute/*` can work without access to `config`.

  - Add `get_fallback_url()` so that the caller no longer need `config.html_host`.
  - Add `create_rust_signer()` so that the caller no longer need `config.private_key_base64`.
  - Add `transform_response_headers()` so that the caller no longer need `config.strip_response_headers`.
  - Add `should_respond_debug_info()`

- Set `Headers` member functions to be `pub(crate)`, becasue `SxgWorker::transform_request_headers` and `SxgWorker::transform_response_headers` do all the header checks. `pub(crate)` means they are public inside `sxg_rs` folder, but not visible to `cloudflare_worker` or `fastly_compute`.