### PR TITLE
Gate console_log on feature="wasm" also.

### DIFF
--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -165,12 +165,12 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcherImpl<'a, F, C> {
     }
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm"))]
 fn console_log(msg: &str) {
     web_sys::console::log_1(&msg.into());
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(all(target_family = "wasm", feature = "wasm")))]
 fn console_log(msg: &str) {
     println!("{}", msg);
 }


### PR DESCRIPTION
fastly_compute is target_family="wasm" but does not provide web_sys::console
bindings.

`cargo test` is feature="wasm" but does not provide the bindings.

Both are needed to select for cloudflare_worker in particular.

I forgot to change this in #57. Feel free to merge this after approval; I will be AFK for a bit.

Addresses #13.