### PR TITLE
Add conditional compilation for JsHttpCache

### DIFF
--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -107,7 +107,7 @@ pub async fn create_signed_exchange(
         .map_err(to_js_error)?;
     let signer = ::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(signer);
     let subresource_fetcher = sxg_rs::fetcher::js_fetcher::JsFetcher::new(subresource_fetcher);
-    let mut header_integrity_cache = sxg_rs::http_cache::JsHttpCache {
+    let mut header_integrity_cache = sxg_rs::http_cache::js_http_cache::JsHttpCache {
         get: header_integrity_get,
         put: header_integrity_put,
     };

--- a/sxg_rs/src/http_cache/js_http_cache.rs
+++ b/sxg_rs/src/http_cache/js_http_cache.rs
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::HttpCache;
+use crate::http::HttpResponse;
+use anyhow::{anyhow, Error, Result};
+use async_trait::async_trait;
+use js_sys::Function as JsFunction;
+use wasm_bindgen::JsValue;
+
+pub struct JsHttpCache {
+    pub get: JsFunction,
+    pub put: JsFunction,
+}
+
+#[async_trait(?Send)]
+impl HttpCache for JsHttpCache {
+    async fn get(&mut self, url: &str) -> Result<HttpResponse> {
+        let url = JsValue::from_serde(&url)
+            .map_err(|e| Error::new(e).context("serializing url to JS"))?;
+        let this = JsValue::null();
+        let response = self
+            .get
+            .call1(&this, &url)
+            .map_err(|_| anyhow!("Error invoking JS get"))?;
+        let response = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(response));
+        let response = response
+            .await
+            .map_err(|_| anyhow!("Error returned by JS get"))?;
+        let response = response
+            .into_serde()
+            .map_err(|e| Error::new(e).context("parsing response from JS"))?;
+        Ok(response)
+    }
+    async fn put(&mut self, url: &str, response: &HttpResponse) -> Result<()> {
+        let url = JsValue::from_serde(&url)
+            .map_err(|e| Error::new(e).context("serializing url to JS"))?;
+        let response = JsValue::from_serde(&response)
+            .map_err(|e| Error::new(e).context("serializing response to JS"))?;
+        let this = JsValue::null();
+        let ret = self
+            .put
+            .call2(&this, &url, &response)
+            .map_err(|_| anyhow!("Error invoking JS put"))?;
+        let ret = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(ret));
+        let ret = ret.await.map_err(|_| anyhow!("Error returned by JS put"))?;
+        let _ret = ret
+            .into_serde()
+            .map_err(|e| Error::new(e).context("parsing ack from JS"))?;
+        Ok(())
+    }
+}

--- a/sxg_rs/src/http_cache/mod.rs
+++ b/sxg_rs/src/http_cache/mod.rs
@@ -1,8 +1,23 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "wasm")]
+pub mod js_http_cache;
+
 use crate::http::HttpResponse;
 use anyhow::{anyhow, Error, Result};
 use async_trait::async_trait;
-use js_sys::Function as JsFunction;
-use wasm_bindgen::JsValue;
 
 /// An interface for storing HTTP responses in a cache.
 #[async_trait(?Send)]
@@ -19,49 +34,6 @@ impl HttpCache for NullCache {
         Err(anyhow!("No cache entry found in NullCache"))
     }
     async fn put(&mut self, _url: &str, _response: &HttpResponse) -> Result<()> {
-        Ok(())
-    }
-}
-
-pub struct JsHttpCache {
-    pub get: JsFunction,
-    pub put: JsFunction,
-}
-
-#[async_trait(?Send)]
-impl HttpCache for JsHttpCache {
-    async fn get(&mut self, url: &str) -> Result<HttpResponse> {
-        let url = JsValue::from_serde(&url)
-            .map_err(|e| Error::new(e).context("serializing url to JS"))?;
-        let this = JsValue::null();
-        let response = self
-            .get
-            .call1(&this, &url)
-            .map_err(|_| anyhow!("Error invoking JS get"))?;
-        let response = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(response));
-        let response = response
-            .await
-            .map_err(|_| anyhow!("Error returned by JS get"))?;
-        let response = response
-            .into_serde()
-            .map_err(|e| Error::new(e).context("parsing response from JS"))?;
-        Ok(response)
-    }
-    async fn put(&mut self, url: &str, response: &HttpResponse) -> Result<()> {
-        let url = JsValue::from_serde(&url)
-            .map_err(|e| Error::new(e).context("serializing url to JS"))?;
-        let response = JsValue::from_serde(&response)
-            .map_err(|e| Error::new(e).context("serializing response to JS"))?;
-        let this = JsValue::null();
-        let ret = self
-            .put
-            .call2(&this, &url, &response)
-            .map_err(|_| anyhow!("Error invoking JS put"))?;
-        let ret = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(ret));
-        let ret = ret.await.map_err(|_| anyhow!("Error returned by JS put"))?;
-        let _ret = ret
-            .into_serde()
-            .map_err(|e| Error::new(e).context("parsing ack from JS"))?;
         Ok(())
     }
 }


### PR DESCRIPTION
`JsHttpCache` uses `wasm_bindgen` crate, which has linking to JS runtime. When Fastly CLI throws an error when [Lucet](https://www.fastly.com/blog/announcing-lucet-fastly-native-webassembly-compiler-runtime) validates the compiled WebAssembly file.
Hence it is needed to disable `wasm_bindgen` (and also `js_sys`, `web_sys`) dependencies when the building target is not WebAssembly.