### PR TITLE
Use clippy to lint code

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -38,4 +38,8 @@ jobs:
         with:
           command: fmt
           args: -- --check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           command: fmt
           args: -- --check
+      - run: |
+          touch credentials/cert.pem
+          touch credentials/issuer.pem
+          touch cloudflare_worker/wrangler.toml
+          touch fastly_compute/fastly.toml
+          touch fastly_compute/config.yaml
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -88,6 +88,7 @@ pub fn validate_payload_headers(fields: JsValue) -> Result<(), JsValue> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 #[wasm_bindgen(js_name=createSignedExchange)]
 pub async fn create_signed_exchange(
     fallback_url: String,

--- a/config_generator/src/main.rs
+++ b/config_generator/src/main.rs
@@ -79,7 +79,7 @@ fn get_global_user() -> GlobalUser {
 // Get the ID of the KV namespace for OCSP.
 // If there is no such KV namespace, one will be created.
 fn get_ocsp_kv_id(user: &GlobalUser, account_id: &str) -> String {
-    let client = wrangler::http::cf_v4_client(&user).unwrap();
+    let client = wrangler::http::cf_v4_client(user).unwrap();
     let target: wrangler::settings::toml::Target = Default::default();
     let namespaces = wrangler::kv::namespace::list(&client, &target).unwrap();
     if let Some(namespace) = namespaces.into_iter().find(|n| n.title == "sxg-OCSP") {
@@ -114,9 +114,9 @@ fn read_certificate_pem_file(path: &str) -> Result<String> {
 fn read_certificates() -> (String, String) {
     let cert = read_certificate_pem_file("credentials/cert.pem");
     let issuer = read_certificate_pem_file("credentials/issuer.pem");
-    if cert.is_ok() && issuer.is_ok() {
+    if let (Ok(cert), Ok(issuer)) = (&cert, &issuer) {
         println!("Successfully read certificates");
-        return (cert.unwrap(), issuer.unwrap());
+        return (cert.to_string(), issuer.to_string());
     }
     if let Err(msg) = cert {
         println!("{}", msg);
@@ -135,9 +135,9 @@ What you need to do:
     std::process::exit(1);
 }
 
-const CONFIG_FILE: &'static str = "cloudflare_worker/wrangler.toml";
+const CONFIG_FILE: &str = "cloudflare_worker/wrangler.toml";
 // TODO: Remove the example toml, and use Rust code to set the default value of WranglerConfig.
-const CONFIG_EXAMPLE_FILE: &'static str = "cloudflare_worker/wrangler.example.toml";
+const CONFIG_EXAMPLE_FILE: &str = "cloudflare_worker/wrangler.example.toml";
 
 // Read and parse `wrangler.toml`.
 // `wrangler.example.toml` will be read if `wrangler.toml` does not exist.
@@ -183,7 +183,7 @@ fn main() -> Result<(), std::io::Error> {
             .unwrap();
         let target = Select::new()
             .with_prompt("Where do you want to deploy the worker?")
-            .items(&vec![
+            .items(&[
                 "On your domain (recommended; required by Google SXG Cache)",
                 "On workers.dev (development only)",
             ])

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -33,9 +33,7 @@ impl FastlyFetcher {
     /// the Fastly backend need to be created via Fastly API
     /// before calling this function.
     pub fn new(backend_name: &'static str) -> Self {
-        FastlyFetcher {
-            backend_name: backend_name,
-        }
+        FastlyFetcher { backend_name }
     }
 }
 

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -94,7 +94,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
     let sxg = WORKER.create_signed_exchange(sxg_rs::CreateSignedExchangeParams {
         now: std::time::SystemTime::now(),
         payload_body: &payload_body,
-        payload_headers: payload_headers,
+        payload_headers,
         signer,
         status_code: 200,
         fallback_url: fallback_url.as_str(),
@@ -119,7 +119,7 @@ fn handle_request(req: Request) -> Result<Response> {
     match WORKER.serve_preset_content(req.get_url_str(), &ocsp_der) {
         Some(PresetContent::Direct(response)) => return Ok(fetcher::from_http_response(response)),
         Some(PresetContent::ToBeSigned { url, payload, .. }) => {
-            fallback_url = Url::parse(&url).map_err(|e| Error::new(e))?;
+            fallback_url = Url::parse(&url).map_err(Error::new)?;
             sxg_payload = fetcher::from_http_response(payload);
             get_req_header_fields(&req, AcceptFilter::AcceptsSxg)?;
         }
@@ -145,7 +145,6 @@ mod tests {
     use super::*;
     #[test]
     fn it_works() {
-        &*WORKER;
         WORKER.create_rust_signer().unwrap();
     }
 }

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -149,7 +149,7 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcherImpl<'a, F, C> {
         .concat())
     }
     fn error_response(msg: &str) -> HttpResponse {
-        console_log(&msg.clone());
+        console_log(msg);
         HttpResponse {
             body: msg.as_bytes().into(),
             ..ERROR_RESPONSE.clone()
@@ -183,7 +183,7 @@ pub mod tests {
     use anyhow::{anyhow, Result};
     use std::collections::HashMap;
 
-    static EMPTY_SET: Lazy<BTreeSet<String>> = Lazy::new(|| BTreeSet::new());
+    static EMPTY_SET: Lazy<BTreeSet<String>> = Lazy::new(BTreeSet::new);
     static mut NULL_CACHE: NullCache = NullCache {};
 
     // For use in other modules' tests.
@@ -238,10 +238,7 @@ pub mod tests {
     #[async_trait(?Send)]
     impl HttpCache for InMemoryCache {
         async fn get(&mut self, url: &str) -> Result<HttpResponse> {
-            self.0
-                .get(url)
-                .map(|r| r.clone())
-                .ok_or(anyhow!("not found"))
+            self.0.get(url).cloned().ok_or_else(|| anyhow!("not found"))
         }
         async fn put(&mut self, url: &str, response: &HttpResponse) -> Result<()> {
             self.0.insert(url.into(), response.clone());

--- a/sxg_rs/src/http_cache/mod.rs
+++ b/sxg_rs/src/http_cache/mod.rs
@@ -16,7 +16,7 @@
 pub mod js_http_cache;
 
 use crate::http::HttpResponse;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 
 /// An interface for storing HTTP responses in a cache.

--- a/sxg_rs/src/http_parser/accept.rs
+++ b/sxg_rs/src/http_parser/accept.rs
@@ -56,7 +56,7 @@ named!(
 
 fn parse_q_millis(s: &str) -> Option<u16> {
     let x = s.parse::<f64>().ok()?;
-    if x >= 0.0 && x <= 1.0 {
+    if (0.0..=1.0).contains(&x) {
         Some((x * 1000.0) as u16)
     } else {
         None

--- a/sxg_rs/src/http_parser/base.rs
+++ b/sxg_rs/src/http_parser/base.rs
@@ -26,12 +26,11 @@ pub fn token(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn is_tchar(c: char) -> bool {
-    match c {
-        '!' | '#' | '$' | '%' | '&' | '\'' | '*' => true,
-        '+' | '-' | '.' | '^' | '_' | '`' | '|' | '~' => true,
-        '0'..='9' | 'A'..='Z' | 'a'..='z' => true,
-        _ => false,
-    }
+    matches!(c,
+        '!' | '#' | '$' | '%' | '&' | '\'' | '*' |
+        '+' | '-' | '.' | '^' | '_' | '`' | '|' | '~' |
+        '0'..='9' | 'A'..='Z' | 'a'..='z'
+    )
 }
 
 fn is_space_or_tab(c: char) -> bool {
@@ -65,21 +64,19 @@ fn qdtext(input: &str) -> IResult<&str, char> {
 }
 
 fn is_qdtext(c: char) -> bool {
-    match c {
-        '\t' | ' ' | '\x21' => true,
-        '\x23'..='\x5B' | '\x5D'..='\x7E' => true,
-        '\u{80}'..=std::char::MAX => true,
-        _ => false,
-    }
+    matches!(c,
+        '\t' | ' ' | '\x21' |
+        '\x23'..='\x5B' | '\x5D'..='\x7E' |
+        '\u{80}'..=std::char::MAX
+    )
 }
 
 pub fn is_quoted_pair_payload(c: char) -> bool {
-    match c {
-        '\t' | ' ' => true,
-        '\x21'..='\x7E' => true,
-        '\u{80}'..=std::char::MAX => true,
-        _ => false,
-    }
+    matches!(c,
+        '\t' | ' ' |
+        '\x21'..='\x7E' |
+        '\u{80}'..=std::char::MAX
+    )
 }
 
 named!(
@@ -90,7 +87,7 @@ named!(
 fn char_if(predicate: fn(c: char) -> bool) -> impl Fn(&str) -> IResult<&str, char> {
     move |input: &str| {
         map_opt!(input, take!(1), |s: &str| {
-            let c = s.chars().nth(0)?;
+            let c = s.chars().next()?;
             if predicate(c) {
                 Some(c)
             } else {

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -33,9 +33,9 @@ pub struct Link<'a> {
 }
 
 fn quote(value: &str) -> Option<String> {
-    if value.chars().all(|c| is_tchar(c)) {
+    if value.chars().all(is_tchar) {
         Some(value.into())
-    } else if value.chars().all(|c| is_quoted_pair_payload(c)) {
+    } else if value.chars().all(is_quoted_pair_payload) {
         Some(
             "\"".to_string()
                 + &value
@@ -80,18 +80,19 @@ fn uri_ref(input: &str) -> IResult<&str, &str> {
     // URL class for parsing and validation. For defense in depth, we only allow
     // the characters specified in
     // https://datatracker.ietf.org/doc/html/rfc3986#appendix-A.
-    take_while(|c: char| match c {
-        // unreserved
-        'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' => true,
-        // gen-delims
-        ':' | '|' | '?' | '#' | '[' | ']' | '@' => true,
-        // sub-delims
-        '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' => true,
-        // pct-encoded
-        '%' => true,
-        // path
-        '/' => true,
-        _ => false,
+    take_while(|c: char| {
+        matches!(c,
+            // unreserved
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~' |
+            // gen-delims
+            ':' | '|' | '?' | '#' | '[' | ']' | '@' |
+            // sub-delims
+            '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '=' |
+            // pct-encoded
+            '%' |
+            // path
+            '/'
+        )
     })(input)
 }
 

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -50,7 +50,7 @@ pub fn parse_accept_header(input: &str) -> Result<Vec<accept::Accept>> {
 pub fn parse_cache_control_header(input: &str) -> Result<Duration> {
     let directives = parse_vec(input, cache_control::directive)?;
     cache_control::freshness_lifetime(directives)
-        .ok_or(Error::msg("Freshness lifetime is implicit"))
+        .ok_or_else(|| Error::msg("Freshness lifetime is implicit"))
 }
 
 pub fn parse_content_type_header(input: &str) -> Result<media_type::MediaType> {

--- a/sxg_rs/src/link.rs
+++ b/sxg_rs/src/link.rs
@@ -31,21 +31,18 @@ pub(crate) async fn process_link_header(
         Lazy::new(|| vec!["", "anonymous"].into_iter().collect());
     match parse_link_header(value) {
         Ok(links) => {
-            let links: Vec<Link> = links
-                .into_iter()
-                .filter(|link| {
-                    link.params.iter().all(|(k, v)| {
-                        ALLOWED_PARAM.contains(k)
-                            && match *k {
-                                "rel" => matches!(v, Some(v) if ALLOWED_REL.contains(v.as_str())),
-                                "crossorigin" => {
-                                    matches!(v, Some(v) if ALLOWED_CROSSORIGIN.contains(v.as_str()))
-                                }
-                                _ => true,
+            let links = links.into_iter().filter(|link| {
+                link.params.iter().all(|(k, v)| {
+                    ALLOWED_PARAM.contains(k)
+                        && match *k {
+                            "rel" => matches!(v, Some(v) if ALLOWED_REL.contains(v.as_str())),
+                            "crossorigin" => {
+                                matches!(v, Some(v) if ALLOWED_CROSSORIGIN.contains(v.as_str()))
                             }
-                    })
+                            _ => true,
+                        }
                 })
-                .collect();
+            });
 
             let (mut preloads, allowed_alt_sxgs) = links
                 .into_iter()
@@ -98,7 +95,7 @@ pub(crate) async fn process_link_header(
     }
 }
 
-fn get_param(params: &Vec<(&str, Option<String>)>, name: &str) -> Option<String> {
+fn get_param(params: &[(&str, Option<String>)], name: &str) -> Option<String> {
     let values: Vec<&Option<String>> = params
         .iter()
         .filter(|(k, _)| *k == name)

--- a/sxg_rs/src/link.rs
+++ b/sxg_rs/src/link.rs
@@ -45,7 +45,6 @@ pub(crate) async fn process_link_header(
             });
 
             let (mut preloads, allowed_alt_sxgs) = links
-                .into_iter()
                 .filter_map(|link| {
                     let uri: String = fallback_url.join(&link.uri).ok()?.into();
                     match get_param(&link.params, "rel") {

--- a/sxg_rs/src/mice.rs
+++ b/sxg_rs/src/mice.rs
@@ -18,7 +18,7 @@ use ::sha2::{Digest, Sha256};
 use std::collections::VecDeque;
 
 pub fn calculate(input: &[u8], record_size: usize) -> (Vec<u8>, Vec<u8>) {
-    if input.len() == 0 {
+    if input.is_empty() {
         return (crate::utils::get_sha(&[0]), vec![]);
     }
     let record_size = std::cmp::min(record_size, input.len());
@@ -45,7 +45,7 @@ pub fn calculate(input: &[u8], record_size: usize) -> (Vec<u8>, Vec<u8>) {
         if i > 0 {
             message.extend_from_slice(&proofs[i]);
         }
-        message.extend_from_slice(&records[i]);
+        message.extend_from_slice(records[i]);
     }
     let integrity = proofs.pop_front().unwrap();
     (integrity, message)

--- a/sxg_rs/src/ocsp/mod.rs
+++ b/sxg_rs/src/ocsp/mod.rs
@@ -48,7 +48,7 @@ fn create_ocsp_request(cert: &X509Certificate, issuer: &X509Certificate) -> Vec<
         signature_algorithm(),
         BerObject::from_obj(BerObjectContent::OctetString(&issuer_name_hash)),
         BerObject::from_obj(BerObjectContent::OctetString(&issuer_key_hash)),
-        BerObject::from_obj(BerObjectContent::Integer(&serial_number)),
+        BerObject::from_obj(BerObjectContent::Integer(serial_number)),
     ]);
     // https://tools.ietf.org/html/rfc6960#section-4.1.1
     // Request         ::=     SEQUENCE {
@@ -98,8 +98,8 @@ pub async fn fetch_from_ca<'a, F: Fetcher>(
     issuer_der: &'a [u8],
     fetcher: F,
 ) -> Vec<u8> {
-    let cert = x509_parser::parse_x509_certificate(&cert_der).unwrap().1;
-    let issuer = x509_parser::parse_x509_certificate(&issuer_der).unwrap().1;
+    let cert = x509_parser::parse_x509_certificate(cert_der).unwrap().1;
+    let issuer = x509_parser::parse_x509_certificate(issuer_der).unwrap().1;
     let aia = cert.extensions().get(&AIA);
     if aia == None {
         // If the certificate doesn't include an AIA section, it is probably a

--- a/sxg_rs/src/signature/js_signer.rs
+++ b/sxg_rs/src/signature/js_signer.rs
@@ -58,7 +58,7 @@ impl JsSigner {
 impl Signer for JsSigner {
     async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
         let a = Uint8Array::new_with_length(message.len() as u32);
-        a.copy_from(&message);
+        a.copy_from(message);
         let this = JsValue::null();
         let sig = self.js_function.call1(&this, &a).map_err(|e| {
             Error::msg(format!("{:?}", e)).context("JavaScript signer throws an error.")
@@ -104,7 +104,7 @@ fn raw_sig_to_asn1(raw: Vec<u8>) -> Result<Vec<u8>> {
 // make it a positive integer. For example, when the input is 0xffff,
 // it will be parsed as a negative number, hence we need to change it to
 // 0x00ffff.
-fn ensure_positive(a: &mut Vec<u8>) -> () {
+fn ensure_positive(a: &mut Vec<u8>) {
     if a[0] >= 0x80 {
         a.insert(0, 0x00);
     }

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -71,7 +71,7 @@ impl<'a> Signature<'a> {
             "HTTP Exchange 1 b3".as_bytes(),
             &[0u8],
             &[32u8],
-            &cert_sha256,
+            cert_sha256,
             &(validity_url.len() as u64).to_be_bytes(),
             validity_url.as_bytes(),
             &date.to_be_bytes(),
@@ -79,7 +79,7 @@ impl<'a> Signature<'a> {
             &(request_url.len() as u64).to_be_bytes(),
             request_url.as_bytes(),
             &(headers.len() as u64).to_be_bytes(),
-            &headers,
+            headers,
         ]
         .concat();
         let sig = signer
@@ -98,12 +98,12 @@ impl<'a> Signature<'a> {
     }
     pub fn serialize(&self) -> Vec<u8> {
         let mut list = ShParamList::new();
-        let mut param = ParamItem::new(&self.id);
+        let mut param = ParamItem::new(self.id);
         param.push(("sig", Some(ShItem::ByteSequence(&self.sig))));
         param.push(("integrity", Some(ShItem::String("digest/mi-sha256-03"))));
-        param.push(("cert-url", Some(ShItem::String(&self.cert_url))));
-        param.push(("cert-sha256", Some(ShItem::ByteSequence(&self.cert_sha256))));
-        param.push(("validity-url", Some(ShItem::String(&self.validity_url))));
+        param.push(("cert-url", Some(ShItem::String(self.cert_url))));
+        param.push(("cert-sha256", Some(ShItem::ByteSequence(self.cert_sha256))));
+        param.push(("validity-url", Some(ShItem::String(self.validity_url))));
         param.push(("date", Some(ShItem::Integer(self.date))));
         param.push(("expires", Some(ShItem::Integer(self.expires))));
         list.push(param);

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -32,7 +32,7 @@ impl RustSigner {
 impl Signer for RustSigner {
     async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
         use p256::ecdsa::signature::Signer as _;
-        let sig = self.private_key.try_sign(&message)?.to_asn1();
+        let sig = self.private_key.try_sign(message)?.to_asn1();
         Ok(sig.as_bytes().to_vec())
     }
 }


### PR DESCRIPTION
- Add [cargo clippy](https://github.com/rust-lang/rust-clippy) command in GitHub actions to lint Rust code
- Fix existing lint warnings.