### PR TITLE
Fetch subresources concurrently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ features by running this:
 ``` bash
 $ go install github.com/WICG/webpackage/go/signedexchange/cmd/dump-signedexchange@latest
 $ dump-signedexchange -uri $URL -headerIntegrity
-$ dump-signedexchange -uri $URL -headerIntegrity
+$ dump-signedexchange -uri $URL -headerIntegrity  # verify it's the same
 ```
 
 If it doesn't, eliminate frequently changing headers from the upstream

--- a/README.md
+++ b/README.md
@@ -67,17 +67,20 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
 ## Preload subresources
 
 LCP can be further improved by instructing Google Search to prefetch
-render-critical subresources for the page. To do so, add a `Link: rel=preload`
-header and a matching `Link: rel=allowed-alt-sxg` header in the upstream
-server, as in [this
-example](https://github.com/WICG/webpackage/blob/main/explainers/signed-exchange-subresource-substitution.md#:~:text=a%20preload%20header%20and%20an%20allowed-alt-sxg%20header).
-To compute the `header-integrity` for each subresource, run:
+render-critical subresources for the page. To do so, add a `Link:
+</foo>;rel=preload;as=bar` HTTP header for each same-origin subresource `/foo`,
+with the `as` parameter set to the [appropriate
+destination](https://fetch.spec.whatwg.org/#concept-request-destination).
+
+SXG uses an extended form of subresource integrity that includes response
+headers; ensure that this `header-integrity` remains constant over multiple
+features by running this:
 
 ``` bash
 $ go install github.com/WICG/webpackage/go/signedexchange/cmd/dump-signedexchange@latest
 $ dump-signedexchange -uri $URL -headerIntegrity
+$ dump-signedexchange -uri $URL -headerIntegrity
 ```
 
-Ensure that the `header-integrity` remains constant over multiple fetches. If
-it doesn't, try eliminating frequently changing headers from the upstream
-response, by adding them to the `strip_response_headers` config param.
+If it doesn't, eliminate frequently changing headers from the upstream
+response by adding them to the `strip_response_headers` config param.

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -108,7 +108,7 @@ pub async fn create_signed_exchange(
         .map_err(to_js_error)?;
     let signer = ::sxg_rs::signature::js_signer::JsSigner::from_raw_signer(signer);
     let subresource_fetcher = sxg_rs::fetcher::js_fetcher::JsFetcher::new(subresource_fetcher);
-    let mut header_integrity_cache = sxg_rs::http_cache::js_http_cache::JsHttpCache {
+    let header_integrity_cache = sxg_rs::http_cache::js_http_cache::JsHttpCache {
         get: header_integrity_get,
         put: header_integrity_put,
     };
@@ -122,7 +122,7 @@ pub async fn create_signed_exchange(
             signer,
             status_code,
             subresource_fetcher,
-            header_integrity_cache: &mut header_integrity_cache,
+            header_integrity_cache,
         })
         .await
         .map_err(to_js_error)?;

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -90,7 +90,6 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
     let payload_body = payload.into_body_bytes();
     let cert_origin = fallback_url.origin().ascii_serialization();
     let subresource_fetcher = FastlyFetcher::new("subresources");
-    let mut null_cache = sxg_rs::http_cache::NullCache {};
     let sxg = WORKER.create_signed_exchange(sxg_rs::CreateSignedExchangeParams {
         now: std::time::SystemTime::now(),
         payload_body: &payload_body,
@@ -103,7 +102,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
         // The fastly crate provides only read access to dictionaries, so
         // header integrities cannot be cached. However, I believe the
         // subresource_fetcher will go through the cache.
-        header_integrity_cache: &mut null_cache,
+        header_integrity_cache: sxg_rs::http_cache::NullCache {},
     });
     let sxg = block_on(sxg)?;
     Ok(fetcher::from_http_response(sxg))

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -341,10 +341,7 @@ pub mod tests {
             .for_each_concurrent(None, |n| {
                 println!("fetch #{}", n);
                 async {
-                    assert_eq!(
-                        fetcher.fetch(TEST_URL).await.unwrap(),
-                        "sha256-blah"
-                    );
+                    assert_eq!(fetcher.fetch(TEST_URL).await.unwrap(), "sha256-blah");
                 }
             })
             .await;

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -342,7 +342,7 @@ pub mod tests {
                 println!("fetch #{}", n);
                 async {
                     assert_eq!(
-                        fetcher.fetch(TEST_URL).await.unwrap().to_string(),
+                        fetcher.fetch(TEST_URL).await.unwrap(),
                         "sha256-blah"
                     );
                 }

--- a/sxg_rs/src/http_cache/js_http_cache.rs
+++ b/sxg_rs/src/http_cache/js_http_cache.rs
@@ -26,7 +26,7 @@ pub struct JsHttpCache {
 
 #[async_trait(?Send)]
 impl HttpCache for JsHttpCache {
-    async fn get(&mut self, url: &str) -> Result<HttpResponse> {
+    async fn get(&self, url: &str) -> Result<HttpResponse> {
         let url = JsValue::from_serde(&url)
             .map_err(|e| Error::new(e).context("serializing url to JS"))?;
         let this = JsValue::null();
@@ -43,7 +43,7 @@ impl HttpCache for JsHttpCache {
             .map_err(|e| Error::new(e).context("parsing response from JS"))?;
         Ok(response)
     }
-    async fn put(&mut self, url: &str, response: &HttpResponse) -> Result<()> {
+    async fn put(&self, url: &str, response: &HttpResponse) -> Result<()> {
         let url = JsValue::from_serde(&url)
             .map_err(|e| Error::new(e).context("serializing url to JS"))?;
         let response = JsValue::from_serde(&response)

--- a/sxg_rs/src/http_cache/mod.rs
+++ b/sxg_rs/src/http_cache/mod.rs
@@ -22,18 +22,18 @@ use async_trait::async_trait;
 /// An interface for storing HTTP responses in a cache.
 #[async_trait(?Send)]
 pub trait HttpCache {
-    async fn get(&mut self, url: &str) -> Result<HttpResponse>;
-    async fn put(&mut self, url: &str, response: &HttpResponse) -> Result<()>;
+    async fn get(&self, url: &str) -> Result<HttpResponse>;
+    async fn put(&self, url: &str, response: &HttpResponse) -> Result<()>;
 }
 
 pub struct NullCache;
 
 #[async_trait(?Send)]
 impl HttpCache for NullCache {
-    async fn get(&mut self, _url: &str) -> Result<HttpResponse> {
+    async fn get(&self, _url: &str) -> Result<HttpResponse> {
         Err(anyhow!("No cache entry found in NullCache"))
     }
-    async fn put(&mut self, _url: &str, _response: &HttpResponse) -> Result<()> {
+    async fn put(&self, _url: &str, _response: &HttpResponse) -> Result<()> {
         Ok(())
     }
 }

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -301,7 +301,7 @@ pub struct CreateSignedExchangeParams<'a, S: signature::Signer, F: Fetcher, C: H
     pub signer: S,
     pub status_code: u16,
     pub subresource_fetcher: F,
-    pub header_integrity_cache: &'a mut C,
+    pub header_integrity_cache: C,
 }
 
 #[cfg(test)]

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -60,6 +60,13 @@ pub async fn signed_headers_and_payload<F: Fetcher, C: HttpCache>(
 
 #[cfg(test)]
 pub mod tests {
+    use futures::{
+        future::{BoxFuture, Future},
+        task::{Context, Poll, Waker},
+    };
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+
     // Generated with:
     //   KEY=`mktemp` && CSR=`mktemp` &&
     //   openssl ecparam -out "$KEY" -name prime256v1 -genkey &&
@@ -83,4 +90,52 @@ SFfkmh8Fc2QXpbbaK5AQfnQpkDHV
     // Generated from above cert using:
     //   openssl x509 -in - -outform DER | openssl dgst -sha256 -binary | base64 | tr /+ _- | tr -d =
     pub const SELF_SIGNED_CERT_SHA256: &str = "Lz2EMcys4NR9FP0yYnuS5Uw8xM3gbVAOM2lwSBU9qX0";
+
+    // Returns a future for the given state object. If multiple futures are created from the same
+    // shared state, the first to be polled resolves after the second.
+    pub fn out_of_order<'a, T: 'a, F: 'a + Fn() -> T + Send>(
+        state: Arc<Mutex<OutOfOrderState>>,
+        value: F,
+    ) -> BoxFuture<'a, T> {
+        Box::pin(OutOfOrderFuture { value, state })
+    }
+
+    pub struct OutOfOrderState {
+        first: bool,
+        waker: Option<Waker>,
+    }
+
+    impl OutOfOrderState {
+        pub fn new() -> Arc<Mutex<Self>> {
+            Arc::new(Mutex::new(OutOfOrderState {
+                first: true,
+                waker: None,
+            }))
+        }
+    }
+
+    struct OutOfOrderFuture<T, F: Fn() -> T> {
+        value: F,
+        state: Arc<Mutex<OutOfOrderState>>,
+    }
+
+    impl<T, F: Fn() -> T> Future for OutOfOrderFuture<T, F> {
+        type Output = T;
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let mut state = &mut *self.state.lock().unwrap();
+            let first = state.first;
+            state.first = false;
+            println!("first = {}", first);
+            if first {
+                state.waker = Some(cx.waker().clone());
+                Poll::Pending
+            } else {
+                if let Some(waker) = &state.waker {
+                    println!("waking!");
+                    waker.wake_by_ref();
+                }
+                Poll::Ready((self.value)())
+            }
+        }
+    }
 }

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -33,7 +33,7 @@ pub async fn signed_headers_and_payload<F: Fetcher, C: HttpCache>(
     payload_headers: &Headers,
     payload_body: &[u8],
     subresource_fetcher: F,
-    header_integrity_cache: &mut C,
+    header_integrity_cache: C,
     strip_response_headers: &BTreeSet<String>,
 ) -> Result<(Vec<u8>, Vec<u8>)> {
     if status_code != 200 {


### PR DESCRIPTION
Requires interior mutability for HeaderIntegrityFetcher, so that a fine-grained
lock can be held for just the mutable HttpCache, without blocking access to the
immutable Fetcher in parallel.

Added a unit test that the operation completes when fetches are returned out of
order.

Fixes #13.

/cc @oliy 