### PR TITLE
Don't backdate SXGs

### DIFF
--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -279,7 +279,7 @@ async function generateSxgResponse(fallbackUrl: string, certOrigin: string, payl
     throw `The size of payload exceeds the limit ${PAYLOAD_SIZE_LIMIT}`;
   }
   let {get: headerIntegrityGet, put: headerIntegrityPut} = await headerIntegrityCache();
-  const now_in_seconds = Math.round(Date.now() / 1000 - 60 * 60 * 12);
+  const now_in_seconds = Math.floor(Date.now() / 1000);
   const sxg = await createSignedExchange(
     fallbackUrl,
     certOrigin,


### PR DESCRIPTION
Remove the 12h backdating of SXGs. This was probably added to allow for clock skew, but:
- the Google SXG cache allows for very-slightly future-dated SXGs, to account for this
- most SXG browsers don't have much clock skew