### PR TITLE
Update der-parser to 6.0.0, x509-parser to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,11 +913,10 @@ dependencies = [
 
 [[package]]
 name = "der-oid-macro"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cccf60bb98c0fca115a581f894aed0e43fa55bf289fdac5599bec440bb4fd6"
+checksum = "c73af209b6a5dc8ca7cbaba720732304792cddc933cfea3d74509c2b1ef2f436"
 dependencies = [
- "nom 6.1.2",
  "num-bigint",
  "num-traits 0.2.14",
  "syn",
@@ -925,13 +924,13 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "5.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120842c2385dea19347e2f6e31caa5dced5ba8afdfacaac16c59465fdd1168f2"
+checksum = "9807efb310ce4ea172924f3a69d82f9fd6c9c3a19336344591153e665b31c43e"
 dependencies = [
  "cookie-factory",
  "der-oid-macro",
- "nom 6.1.2",
+ "nom 7.0.0",
  "num-bigint",
  "num-traits 0.2.14",
  "rusticata-macros",
@@ -2035,6 +2034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +2181,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26c042283b4ecc71edde70de2d6d0ab7e8743b8e7a7cb8467e4d153dfc7ad43"
+checksum = "fe554cb2393bc784fd678c82c84cc0599c31ceadc7f03a594911f822cb8d1815"
 dependencies = [
  "der-parser",
 ]
@@ -2836,11 +2852,11 @@ checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rusticata-macros"
-version = "3.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+checksum = "65c52377bb2288aa522a0c8208947fada1e0c76397f108cc08f57efe6077b50d"
 dependencies = [
- "nom 6.1.2",
+ "nom 7.0.0",
 ]
 
 [[package]]
@@ -4191,19 +4207,18 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x509-parser"
-version = "0.9.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64abca276c58f8341ddc13fd4bd6ae75993cc669043f5b34813c90f7dff04771"
+checksum = "ffc90836a84cb72e6934137b1504d0cae304ef5d83904beb0c8d773bbfe256ed"
 dependencies = [
  "base64 0.13.0",
  "chrono",
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom 6.1.2",
+ "nom 7.0.0",
  "oid-registry",
  "rusticata-macros",
- "rustversion",
  "thiserror",
 ]
 

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -30,7 +30,7 @@ wasm =[]
 anyhow = "1.0.43"
 async-trait = "0.1.50"
 base64 = "0.13.0"
-der-parser = { version = "5.1.0", features = ["bigint", "serialize"] }
+der-parser = { version = "6.0.0", features = ["bigint", "serialize"] }
 futures = { version = "0.3.14", features = ["executor"] }
 js-sys = "0.3.50"
 nom = { version = "6.1.2", features = ["alloc"] }
@@ -44,7 +44,7 @@ url = "2.2.2"
 wasm-bindgen = { version = "0.2.73", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.23"
 web-sys = { version = "0.3.42", features = ["console"] }
-x509-parser = "0.9.2"
+x509-parser = "0.12.0"
 
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -162,7 +162,10 @@ impl SxgWorker {
         validity.serialize()
     }
     pub async fn fetch_ocsp_from_ca<F: fetcher::Fetcher>(&self, fetcher: F) -> Vec<u8> {
-        ocsp::fetch_from_ca(&self.config.cert_der, &self.config.issuer_der, fetcher).await
+        let result =
+            ocsp::fetch_from_ca(&self.config.cert_der, &self.config.issuer_der, fetcher).await;
+        // TODO: Remove panic
+        result.unwrap()
     }
     pub fn serve_preset_content(&self, req_url: &str, ocsp_der: &[u8]) -> Option<PresetContent> {
         let req_url = url::Url::parse(req_url).ok()?;

--- a/sxg_rs/src/ocsp/mod.rs
+++ b/sxg_rs/src/ocsp/mod.rs
@@ -113,9 +113,10 @@ pub async fn fetch_from_ca<'a, F: Fetcher>(
         // self-signed certificate. Return a stub OCSP response.
         return Ok(b"ocsp".to_vec());
     };
-    let aia = match aia.parsed_extension() {
-        ParsedExtension::AuthorityInfoAccess(aia) => aia,
-        _ => return Err(anyhow!("Failed to parse AIA extension")),
+    let aia = if let ParsedExtension::AuthorityInfoAccess(aia) = aia.parsed_extension() {
+        aia
+    } else {
+        return Err(anyhow!("Failed to parse AIA extension"));
     };
     let url = aia
         .accessdescs


### PR DESCRIPTION
- Upgrade `der-parser` to `6.0.0`, `x509-parser` to `0.12.0`.
- Change `ocsp::fetch_from_ca` to return a `Result`.
  - The panic is now moved to `SxgWorker::fetch_ocsp_from_ca`, and a TODO is added to fix it. We don't fix it in this PR to prevent merging conflict with another pending PR #71.
- Refactor `ocsp::fetch_from_ca` to improve readability. The behavior of checking `aia.accessdescs` is slightly changed.
   - Old code: panics if the first `AIA_OCSP` is not a URL.
   - New code: check every `AIA_OCSP` until find a URL.
 

Fixes unit tests in #66.