### PR TITLE
Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,16 @@ exchanges](https://web.dev/signed-exchanges/) at serve time:
   * [`fastly_compute`](fastly_compute) runs on [Fastly Compute@Edge](https://www.fastly.com/products/edge-compute/serverless).
   * [`sxg_rs`](sxg_rs) is the Rust library that drives both, and could be used as a basis for other serverless platforms.
 
-The tools here are designed to enable sites to be [prefetched from Google
+These tools enable sites to be [prefetched from Google
 Search](https://developers.google.com/search/docs/advanced/experience/signed-exchange)
 in order to improve their [Largest Contentful Paint](https://web.dev/lcp/), one
 of the [Core Web Vitals](https://web.dev/vitals/).
 
-## Verify and monitor
+## Next steps
+
+After installing, take the following steps.
+
+### Verify and monitor
 
 This code was released in July 2021 and thus hasn't yet had a lot of real-world
 testing. After installing, please
@@ -37,34 +41,7 @@ and
 [monitor](https://developers.google.com/search/docs/advanced/experience/signed-exchange#monitor-and-debug-sxg)
 the results.
 
-### Preview in Chrome
-
-To preview the results in the browser:
-
- - In development, set Chrome flags to [allow the
-   certificate](https://github.com/google/webpackager/tree/main/cmd/webpkgserver#testing-with-self-signed--invalid-certificates).
- - Use an extension such as
-   [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj)
-   to set the `Accept` header to
-   `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3`
-   (equivalent to what Googlebot sends).
- - Explore the results [in the DevTools Network tab](https://web.dev/signed-exchanges/#debugging).
-
-## Ensure compatibility with SXG
-
-The Google SXG Cache may reuse an SXG for several visits to the page, or for
-several users (until SXG expiration). Follow [these
-instructions](https://developers.google.com/search/docs/advanced/experience/signed-exchange#additional-requirements-for-google-search)
-to ensure all signed pages are compatible with such reuse. To opt some pages
-out of signing, set the `Cache-Control` header to include `private` or
-`no-store` in the upstream server.
-
-The Google SXG Cache tries to [update SXGs
-often](https://developers.google.com/search/docs/advanced/experience/signed-exchange#:~:text=Regardless%20of%20the,the%20SXG%20response.),
-but may reuse them for up to 7 days. To ensure they expire sooner, set
-`s-maxage` or `max-age` on the `Cache-Control` header on the upstream server.
-
-## Preload subresources
+### Preload subresources
 
 LCP can be further improved by instructing Google Search to prefetch
 render-critical subresources for the page. To do so, add a `Link:
@@ -72,9 +49,9 @@ render-critical subresources for the page. To do so, add a `Link:
 with the `as` parameter set to the [appropriate
 destination](https://fetch.spec.whatwg.org/#concept-request-destination).
 
-SXG uses an extended form of subresource integrity that includes response
-headers; ensure that this `header-integrity` remains constant over multiple
-features by running this:
+Behind the scenes, SXG uses an extended form of subresource integrity that
+includes response headers; ensure that this `header-integrity` will remain
+constant over multiple features by running this:
 
 ``` bash
 $ go install github.com/WICG/webpackage/go/signedexchange/cmd/dump-signedexchange@latest
@@ -84,3 +61,16 @@ $ dump-signedexchange -uri $URL -headerIntegrity  # verify it's the same
 
 If it doesn't, eliminate frequently changing headers from the upstream
 response by adding them to the `strip_response_headers` config param.
+
+### Preview in Chrome
+
+Optionally, preview the results in the browser:
+
+ - In development, set Chrome flags to [allow the
+   certificate](https://github.com/google/webpackager/tree/main/cmd/webpkgserver#testing-with-self-signed--invalid-certificates).
+ - Use an extension such as
+   [ModHeader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj)
+   to set the `Accept` header to
+   `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3`
+   (equivalent to what Googlebot sends).
+ - Explore the results [in the DevTools Network tab](https://web.dev/signed-exchanges/#debugging).

--- a/cloudflare_worker/README.md
+++ b/cloudflare_worker/README.md
@@ -14,7 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## Setup
+# sxg-rs/cloudflare_worker
+
+This is a [Cloudflare Worker](https://workers.cloudflare.com/) that
+automatically generates [signed exchanges](https://web.dev/signed-exchanges/) (SXGs)
+for your site. It enables the site to be [prefetched from Google
+Search](https://developers.google.com/search/docs/advanced/experience/signed-exchange)
+in order to improve its [Largest Contentful Paint](https://web.dev/lcp/),
+one of the [Core Web Vitals](https://web.dev/vitals/).
+
+## Ensure compatibility with SXG
+
+The Google SXG Cache may reuse an SXG for several visits to the page, or for
+several users (until SXG expiration). Before installing this worker with a
+production certificate, follow [these
+instructions](https://developers.google.com/search/docs/advanced/experience/signed-exchange#additional-requirements-for-google-search)
+to ensure all signed pages are compatible with such reuse. To opt some pages
+out of signing, set the `Cache-Control` header to include `private` or
+`no-store` in the upstream server.
+
+The Google SXG Cache tries to [update SXGs
+often](https://developers.google.com/search/docs/advanced/experience/signed-exchange#:~:text=Regardless%20of%20the,the%20SXG%20response.),
+but may reuse them for up to 7 days. To ensure they expire sooner, set
+`s-maxage` or `max-age` on the `Cache-Control` header on the upstream server.
+
+## Install
 
 1. Get an SXG-compatible certificate
    using [these steps](../credentials/README.md#get-an-sxg_compatible-certificate).
@@ -57,7 +81,7 @@ limitations under the License.
 1. To check whether the worker generates a valid SXG,
    use Chrome browser to open `https://${WORKER_HOST}/.sxg/test.html`.
 
-1. Read on for [next steps](../README.md).
+1. Read on for [next steps](../README.md#next-steps).
 
 ## Maintenance
 

--- a/cloudflare_worker/README.md
+++ b/cloudflare_worker/README.md
@@ -83,7 +83,7 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
 
 1. Read on for [next steps](../README.md#next-steps).
 
-## Maintenance
+## Maintain
 
 The certificates need to be renewed every 90 days.
 

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -94,8 +94,6 @@ SXGs.
    and rename `your_domain.crt` as `cert.pem`. Place them in this `credentials/`
    directory.
 
-A production certificate enables the Google SXG Cache to prefetch and cache the SXG.
-
 #### Renew certificate
 
 Production certificates need to be renewed every 90 days.

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -76,6 +76,8 @@ not work in production.
 
 For use in production, a SXG certificate must be obtained from a [Certificate
 Authority](https://github.com/google/webpackager/wiki/Certificate-Authorities).
+A production certificate enables the Google SXG Cache to prefetch your site's
+SXGs.
 
 1. Follow the [DigiCert
    doc](https://docs.digicert.com/manage-certificates/certificate-profile-options/get-your-signed-http-exchange-certificate/).
@@ -91,6 +93,8 @@ Authority](https://github.com/google/webpackager/wiki/Certificate-Authorities).
 1. From the files issued by DigiCert, rename `DigiCertCA.crt` as `issuer.pem`,
    and rename `your_domain.crt` as `cert.pem`. Place them in this `credentials/`
    directory.
+
+A production certificate enables the Google SXG Cache to prefetch and cache the SXG.
 
 #### Renew certificate
 

--- a/fastly_compute/README.md
+++ b/fastly_compute/README.md
@@ -92,7 +92,7 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
 
 1. Read on for [next steps](../README.md#next-steps).
 
-## Maintenance
+## Maintain
 
 The certificates need to be renewed every 90 days.
 

--- a/fastly_compute/README.md
+++ b/fastly_compute/README.md
@@ -14,7 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## Setup
+# sxg-rs/cloudflare_worker
+
+This is a [Fastly Compute@Edge app](https://www.fastly.com/products/edge-compute/serverless) that
+automatically generates [signed exchanges](https://web.dev/signed-exchanges/) (SXGs)
+for your site. It enables the site to be [prefetched from Google
+Search](https://developers.google.com/search/docs/advanced/experience/signed-exchange)
+in order to improve its [Largest Contentful Paint](https://web.dev/lcp/),
+one of the [Core Web Vitals](https://web.dev/vitals/).
+
+## Ensure compatibility with SXG
+
+The Google SXG Cache may reuse an SXG for several visits to the page, or for
+several users (until SXG expiration). Before installing this app with a
+production certificate, follow [these
+instructions](https://developers.google.com/search/docs/advanced/experience/signed-exchange#additional-requirements-for-google-search)
+to ensure all signed pages are compatible with such reuse. To opt some pages
+out of signing, set the `Cache-Control` header to include `private` or
+`no-store` in the upstream server.
+
+The Google SXG Cache tries to [update SXGs
+often](https://developers.google.com/search/docs/advanced/experience/signed-exchange#:~:text=Regardless%20of%20the,the%20SXG%20response.),
+but may reuse them for up to 7 days. To ensure they expire sooner, set
+`s-maxage` or `max-age` on the `Cache-Control` header on the upstream server.
+
+## Install
 
 1. Get an SXG-compatible certificate
    using [these steps](../credentials/README.md#get-an-sxg_compatible-certificate).
@@ -66,7 +90,7 @@ limitations under the License.
 1. To check whether the worker generates a valid SXG,
    use Chrome browser to open `https://${WORKER_HOST}/.sxg/test.html`.
 
-1. Read on for [next steps](../README.md).
+1. Read on for [next steps](../README.md#next-steps).
 
 ## Maintenance
 

--- a/sxg_rs/README.md
+++ b/sxg_rs/README.md
@@ -1,0 +1,6 @@
+# sxg-rs
+
+A Rust library that generate [signed
+exchanges](https://web.dev/signed-exchanges/) for given HTTP request/response
+pairs. For example usages, see [`cloudflare_worker`](../cloudflare_worker) and
+[`fastly_compute`](fastly_compute).

--- a/sxg_rs/README.md
+++ b/sxg_rs/README.md
@@ -3,4 +3,4 @@
 A Rust library that generate [signed
 exchanges](https://web.dev/signed-exchanges/) for given HTTP request/response
 pairs. For example usages, see [`cloudflare_worker`](../cloudflare_worker) and
-[`fastly_compute`](fastly_compute).
+[`fastly_compute`](../fastly_compute).


### PR DESCRIPTION
Add the necessary info to the READMEs for cloudflare_worker and fastly_compute
so that they can be effective landing pages. This introduces some doc
duplication, but it seems preferable over making the visitor jump
back-and-forth between docs.

Move the "preview" section to the bottom since it's the lowest priority.

Also add a stub README for the library. Before making this a crate, we should
expand this README and add doc comments to the code.

/cc @khempenius