### PR TITLE
Enable "js" feature for getrandom.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,8 +1510,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3263,6 +3265,7 @@ dependencies = [
  "base64 0.13.0",
  "der-parser",
  "futures",
+ "getrandom 0.2.3",
  "js-sys",
  "nom 6.1.2",
  "once_cell",

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = "0.1.50"
 base64 = "0.13.0"
 der-parser = { version = "6.0.0", features = ["bigint", "serialize"] }
 futures = { version = "0.3.14", features = ["executor"] }
+getrandom = { version = "0.2.3", features = ["js"] }
 js-sys = "0.3.50"
 nom = { version = "6.1.2", features = ["alloc"] }
 once_cell = "1.7.2"


### PR DESCRIPTION
This fixes `wrangler build`, which is not in our GH test workflow. I think it
was broken either by 26cf84c or 2418b66.