### PR TITLE
Fix the backdating code not to cause invalid SXGs.

### DIFF
--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -51,7 +51,7 @@ pub(crate) const BACKDATING: Duration = Duration::from_secs(60 * 60);
 // Maximum signature duration per https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#section-3.5-7.3.
 // We subtract BACKDATING because the calling code only backdates date, not expires, so we don't
 // want to generate SXGs with a too-long duration.
-const SEVEN_DAYS: Duration = Duration::from_secs(60 * 60 * 24 * 7) - BACKDATING;
+const SEVEN_DAYS: Duration = Duration::from_secs(60 * 60 * 24 * 7 - 60 * 60);
 
 impl Headers {
     pub(crate) fn new(data: HeaderFields, strip_headers: &BTreeSet<String>) -> Self {

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -43,8 +43,15 @@ pub enum AcceptFilter {
 // A default mobile user agent, for when the upstream request doesn't include one.
 const USER_AGENT: &str = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36";
 
+// To avoid issues with clock skew, backdate the start time by an hour. Don't backdate the
+// expiration because it goes against the origin's cache-control header. (e.g. For max-age
+// <1h, an SXG would be instantly invalid; this would be confusing.)
+pub(crate) const BACKDATING: Duration = Duration::from_secs(60 * 60);
+
 // Maximum signature duration per https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#section-3.5-7.3.
-const SEVEN_DAYS: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+// We subtract BACKDATING because the calling code only backdates date, not expires, so we don't
+// want to generate SXGs with a too-long duration.
+const SEVEN_DAYS: Duration = Duration::from_secs(60 * 60 * 24 * 7) - BACKDATING;
 
 impl Headers {
     pub(crate) fn new(data: HeaderFields, strip_headers: &BTreeSet<String>) -> Self {

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -34,7 +34,7 @@ mod wasm_worker;
 use anyhow::{anyhow, Error, Result};
 use config::Config;
 use fetcher::Fetcher;
-use headers::{AcceptFilter, Headers};
+use headers::{AcceptFilter, BACKDATING, Headers};
 use http::{HeaderFields, HttpResponse};
 use http_cache::HttpCache;
 use serde::Serialize;
@@ -130,15 +130,13 @@ impl SxgWorker {
                 &self.config.validity_url_dirname, "validity"
             ))
             .map_err(|e| Error::new(e).context("Failed to parse validity_url_dirname"))?;
-        // To avoid issues with clock skew, backdate the start time by an hour. Don't backdate the
-        // expiration because it goes against the origin's cache-control header. (e.g. For max-age
-        // <1h, an SXG would be instantly invalid; this would be confusing.)
+        // To avoid issues with clock skew, backdate the start time but not the expiration (see
+        // details on the comments in the headers.rs).
         let expires = now
             .checked_add(payload_headers.signature_duration()?)
             .ok_or_else(|| anyhow!("Failed to construct expires"))?;
-        const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
         let date = now
-            .checked_sub(ONE_HOUR)
+            .checked_sub(BACKDATING)
             .ok_or_else(|| anyhow!("Failed to construct date"))?;
         let signature = signature::Signature::new(signature::SignatureParams {
             cert_url: cert_url.as_str(),

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -38,7 +38,6 @@ use headers::{AcceptFilter, Headers, BACKDATING};
 use http::{HeaderFields, HttpResponse};
 use http_cache::HttpCache;
 use serde::Serialize;
-use std::time::Duration;
 use url::Url;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -34,7 +34,7 @@ mod wasm_worker;
 use anyhow::{anyhow, Error, Result};
 use config::Config;
 use fetcher::Fetcher;
-use headers::{AcceptFilter, BACKDATING, Headers};
+use headers::{AcceptFilter, Headers, BACKDATING};
 use http::{HeaderFields, HttpResponse};
 use http_cache::HttpCache;
 use serde::Serialize;


### PR DESCRIPTION
Subtract one hour from the SEVEN_DAYS constant so that expires-date is never
>7d, even when date is backdated by an hour. Fixes a bug caused by e605b3c5.

/cc @banaag @caoboxiao I'm going to merge this without review, but please review after the fact and clean up if necessary. e.g. Add tests, and tweak the code structure to prevent errors like this in the future (e.g. maybe signature_duration should be changed to take a `now` param and return a start/end time pair instead of a duration; or maybe clipping expires to 7 days after date should occur in signature/mod.rs).