### PR TITLE
Upgrade nom to 7.0.0 and pem to 1.0.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,18 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,12 +1353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "futures"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,19 +2143,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
-dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
@@ -2428,9 +2397,9 @@ checksum = "3cacbb3c4ff353b534a67fb8d7524d00229da4cb1dc8c79f4db96e375ab5b619"
 
 [[package]]
 name = "pem"
-version = "0.8.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+checksum = "3f2373df5233932a893d3bc2c78a0bf3f6d12590a1edd546b4fbefcac32c5c0f"
 dependencies = [
  "base64 0.13.0",
  "once_cell",
@@ -2617,12 +2586,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -3321,7 +3284,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.3",
  "js-sys",
- "nom 6.2.1",
+ "nom 7.0.0",
  "once_cell",
  "p256",
  "pem",
@@ -3383,12 +3346,6 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3755,8 +3712,8 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.7.3",
+ "cfg-if 1.0.0",
+ "rand 0.8.4",
  "static_assertions",
 ]
 
@@ -4178,12 +4135,6 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x509-parser"

--- a/config_generator/Cargo.toml
+++ b/config_generator/Cargo.toml
@@ -25,7 +25,7 @@ cloudflare = "0.8.7"
 console = "0.14.1"
 ctrlc = "3.2.0"
 dialoguer = "0.8.0"
-pem = "0.8.3"
+pem = "1.0.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"

--- a/config_generator/src/main.rs
+++ b/config_generator/src/main.rs
@@ -98,7 +98,7 @@ fn read_certificate_pem_file(path: &str) -> Result<String> {
     // not rendered in the toml. This is purely cosmetic; '\r' is deserialized
     // faithfully from toml and pem::parse_many is able to parse either style.
     let text = text.replace("\r\n", "\n");
-    let certs = pem::parse_many(&text);
+    let certs = pem::parse_many(&text).map_err(Error::new)?;
     if certs.len() == 1 && certs[0].tag == "CERTIFICATE" {
         Ok(text)
     } else {

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -31,7 +31,7 @@ futures = { version = "0.3.17", features = ["executor"] }
 log = "0.4.14"
 log-fastly = "0.8.0"
 once_cell = "1.8.0"
-pem = "0.8.3"
+pem = "1.0.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 sxg_rs = { path = "../sxg_rs", features = ["rust_signer"] }

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -34,10 +34,10 @@ der-parser = { version = "6.0.0", features = ["bigint", "serialize"] }
 futures = { version = "0.3.17", features = ["executor"] }
 getrandom = { version = "0.2.3", features = ["js"] }
 js-sys = "0.3.55"
-nom = { version = "6.2.1", features = ["alloc"] }
+nom = { version = "7.0.0", features = ["alloc"] }
 once_cell = "1.8.0"
 p256 = { version = "0.9.0", features = ["ecdsa"] }
-pem = "0.8.3"
+pem = "1.0.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 sha2 = "0.9.8"

--- a/sxg_rs/src/http_parser/cache_control.rs
+++ b/sxg_rs/src/http_parser/cache_control.rs
@@ -14,8 +14,13 @@
 
 use super::base::{parameter_value, token};
 use nom::{
-    branch::alt, bytes::complete::tag_no_case, character::complete::char, combinator::map,
-    combinator::map_res, combinator::opt, sequence::pair, sequence::preceded, IResult,
+    branch::alt,
+    bytes::complete::tag_no_case,
+    character::complete::char,
+    combinator::{map, map_res, opt},
+    sequence::pair,
+    sequence::preceded,
+    IResult,
 };
 use std::time::Duration;
 
@@ -93,8 +98,8 @@ mod tests {
         assert_eq!(directive("s-maxage=-1").unwrap(), ("", Directive::Other));
         assert_eq!(directive("s-maxage=1e6").unwrap(), ("", Directive::Other));
         assert_eq!(
-            directive("s-maxage=\"3600").unwrap_err().to_string(),
-            "Parsing requires more data"
+            directive("s-maxage=\"3600").unwrap(),
+            ("=\"3600", Directive::Other)
         );
     }
     #[test]
@@ -110,8 +115,8 @@ mod tests {
         assert_eq!(directive("max-age=-1").unwrap(), ("", Directive::Other));
         assert_eq!(directive("max-age=1e6").unwrap(), ("", Directive::Other));
         assert_eq!(
-            directive("max-age=\"3600").unwrap_err().to_string(),
-            "Parsing requires more data"
+            directive("max-age=\"3600").unwrap(),
+            ("=\"3600", Directive::Other)
         );
     }
     #[test]
@@ -126,8 +131,8 @@ mod tests {
             ("", Directive::Other)
         );
         assert_eq!(
-            directive("no-cache=\"set-cookie").unwrap_err().to_string(),
-            "Parsing requires more data"
+            directive("no-cache=\"set-cookie").unwrap(),
+            ("=\"set-cookie", Directive::Other)
         );
     }
     #[test]

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -161,10 +161,16 @@ mod tests {
                 }
             )
         );
-        assert!(matches!(
-            link(r#"</foo>;bar="baz \""#).unwrap_err(),
-            nom::Err::Incomplete(_)
-        ));
+        assert_eq!(
+            link(r#"</foo>;bar="baz \""#).unwrap(),
+            (
+                r#"="baz \""#,
+                Link {
+                    uri: "/foo".into(),
+                    params: vec![("bar", None)],
+                }
+            )
+        );
     }
     #[test]
     fn serialize() {

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -21,8 +21,13 @@ pub mod media_type;
 use anyhow::{Error, Result};
 use base::ows;
 use nom::{
-    branch::alt, bytes::complete::tag, character::complete::char as char1, combinator::complete,
-    eof, separated_list0, separated_pair, IResult,
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::char as char1,
+    combinator::{complete, eof},
+    multi::separated_list0,
+    sequence::{separated_pair, terminated},
+    IResult,
 };
 use std::time::Duration;
 
@@ -35,10 +40,11 @@ fn parse_vec<'a, F, T>(input: &'a str, parse_single: F) -> Result<Vec<T>>
 where
     F: Fn(&'a str) -> IResult<&'a str, T>,
 {
-    let (input, items) =
-        separated_list0!(input, separated_pair!(ows, char1(','), ows), parse_single)
-            .map_err(format_nom_err)?;
-    eof!(input,).map_err(format_nom_err)?;
+    let (_input, items) = terminated(
+        separated_list0(separated_pair(ows, char1(','), ows), parse_single),
+        eof,
+    )(input)
+    .map_err(format_nom_err)?;
     Ok(items)
 }
 
@@ -84,5 +90,11 @@ mod tests {
             vec!["*", "cookie"]
         );
         assert!(parse_vary_header("tokens only; no spaces or semicolons allowed").is_err());
+    }
+    #[test]
+    fn incomplete_is_err() {
+        assert!(parse_cache_control_header("max-age=\"3600").is_err());
+        assert!(parse_link_header(r#"</foo>;bar="baz \""#).is_err());
+        assert!(parse_vary_header("incomplete,").is_err());
     }
 }

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -44,8 +44,8 @@ where
         separated_list0(separated_pair(ows, char1(','), ows), parse_single),
         eof,
     )(input)
-        .map(|(_, items)| items)
-        .map_err(format_nom_err)
+    .map(|(_, items)| items)
+    .map_err(format_nom_err)
 }
 
 pub fn parse_accept_header(input: &str) -> Result<Vec<accept::Accept>> {


### PR DESCRIPTION
For nom, the biggest change is the removal of the macros and migration to
function combinators. The second biggest change is the way that alt handles
Incomplete; luckily this only affects internal APIs, and hence required changes
to unit tests only.

For pem, the return type changed from Vec<u8> to Result<Vec<u8>>.

This subsumes #80.