### PR TITLE
Add integration tests for cloudflare and fastly.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,86 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Integration tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  cloudflare_worker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create self-signed cert
+        working-directory: credentials
+        run: |
+          openssl ecparam -out privkey.pem -name prime256v1 -genkey
+          openssl req -new -sha256 -key privkey.pem -out cert.csr \
+            -subj '/CN=example.org/O=Test/C=US'
+          openssl x509 -req -days 90 -in cert.csr -signkey privkey.pem -out cert.pem \
+            -extfile <(echo -e "1.3.6.1.4.1.11129.2.1.22 = ASN1:NULL\nsubjectAltName=DNS:example.org")
+          cp cert.pem issuer.pem
+          openssl x509 -pubkey -noout -in cert.pem |\
+            openssl pkey -pubin -outform der |\
+            openssl dgst -sha256 -binary |\
+            base64 >cert_sha256.txt
+      - run: npm install -g @cloudflare/wrangler
+      - name: Build
+        working-directory: cloudflare_worker
+        run: |
+          cp wrangler.example.toml wrangler.toml
+          ./publish.sh build
+      # TODO: ./publish.sh dev & curl | dump-signedexchange -verify.
+  fastly_compute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create self-signed cert
+        working-directory: credentials
+        run: |
+          openssl ecparam -out privkey.pem -name prime256v1 -genkey
+          openssl req -new -sha256 -key privkey.pem -out cert.csr \
+            -subj '/CN=example.org/O=Test/C=US'
+          openssl x509 -req -days 90 -in cert.csr -signkey privkey.pem -out cert.pem \
+            -extfile <(echo -e "1.3.6.1.4.1.11129.2.1.22 = ASN1:NULL\nsubjectAltName=DNS:example.org")
+          cp cert.pem issuer.pem
+          openssl x509 -pubkey -noout -in cert.pem |\
+            openssl pkey -pubin -outform der |\
+            openssl dgst -sha256 -binary |\
+            base64 >cert_sha256.txt
+      - name: Install fastly CLI
+        run: |
+          wget -nv https://github.com/fastly/cli/releases/download/v0.39.2/fastly_0.39.2_linux_amd64.deb
+          sudo apt-get install ./fastly_0.39.2_linux_amd64.deb
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-wasi
+      - name: Build and validate
+        working-directory: fastly_compute
+        run: |
+          cp fastly.example.toml fastly.toml
+          cp config.example.yaml config.yaml
+          fastly compute build
+          fastly compute validate -p pkg/SXG.tar.gz
+      - name: Serve
+        working-directory: fastly_compute
+        run: |
+          fastly compute serve --skip-build | tee log &
+          until grep -m1 'Listening on http' log; do sleep 1; done
+          kill $!
+      # TODO: curl | dump-signedexchange -verify.


### PR DESCRIPTION
Only checks that the systems build; this should be enough to catch the
breakages introduced in commit df66eb3 and fixed in commits 15f6d36 and
b814b6b, for instance.

A future PR will validate the signed exchanges they produce.

Addresses #42.