### PR TITLE
Remove wasm_bindgen attribute from SxgWorker

### DIFF
--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -39,10 +39,7 @@ use http::{HeaderFields, HttpResponse};
 use http_cache::HttpCache;
 use serde::Serialize;
 use url::Url;
-#[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
 
-#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct SxgWorker {
     config: Config,
 }


### PR DESCRIPTION
The `wasm_bindgen` attr for the worker struct was introduced in #71. However, only `WasmWorker` need to be exported to JavaScript, and the struct `SxgWorker` does not need to be exported by `wasm_bindgen`.