### PR TITLE
Add a test for SXG generation.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           cp wrangler.example.toml wrangler.toml
           ./publish.sh build
-      # TODO: ./publish.sh dev & curl | dump-signedexchange -verify.
+      # TODO: ./publish.sh dev & curl | dump-signedexchange -verify
   fastly_compute:
     runs-on: ubuntu-latest
     steps:
@@ -83,4 +83,38 @@ jobs:
           fastly compute serve --skip-build | tee log &
           until grep -m1 'Listening on http' log; do sleep 1; done
           kill $!
-      # TODO: curl | dump-signedexchange -verify.
+      # TODO: curl | dump-signedexchange -verify
+  # TODO: Get rid of this once dump-signedexchange works on the above two cases.
+  gen_sxg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create self-signed cert
+        working-directory: credentials
+        run: |
+          openssl ecparam -out privkey.pem -name prime256v1 -genkey
+          openssl req -new -sha256 -key privkey.pem -out cert.csr \
+            -subj '/CN=example.org/O=Test/C=US'
+          openssl x509 -req -days 90 -in cert.csr -signkey privkey.pem -out cert.pem \
+            -extfile <(echo -e "1.3.6.1.4.1.11129.2.1.22 = ASN1:NULL\nsubjectAltName=DNS:example.org")
+          cp cert.pem issuer.pem
+          openssl x509 -pubkey -noout -in cert.pem |\
+            openssl pkey -pubin -outform der |\
+            openssl dgst -sha256 -binary |\
+            base64 >cert_sha256.txt
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '>=1.16'
+      - run: go install github.com/WICG/webpackage/go/signedexchange/cmd/dump-signedexchange@latest
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-wasi
+      - name: Generate and validate
+        run: |
+          sed "s|private_key_base64: .*|private_key_base64: '$(go run ./credentials/parse_private_key.go <credentials/privkey.pem | tail -1)'|" \
+            fastly_compute/config.example.yaml >config.yaml
+          cargo run -p sxg_rs --bin gen_sxg --features=rust_signer -- \
+            config.yaml credentials/cert.pem credentials/issuer.pem \
+            test.cert test.sxg
+          dump-signedexchange -i test.sxg -cert test.cert -verify

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,40 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2355,6 +2386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+
+[[package]]
 name = "p256"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,9 +2608,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -3248,7 +3285,7 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static",
  "structopt-derive",
 ]
@@ -3280,6 +3317,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "base64 0.13.0",
+ "clap 3.0.0-beta.4",
  "der-parser",
  "futures",
  "getrandom 0.2.3",
@@ -3300,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3443,6 +3481,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]
@@ -4068,7 +4115,7 @@ dependencies = [
  "binary-install",
  "chrome-devtools-rs",
  "chrono",
- "clap",
+ "clap 2.33.3",
  "cloudflare",
  "colored_json",
  "config",

--- a/config_generator/src/main.rs
+++ b/config_generator/src/main.rs
@@ -152,8 +152,6 @@ fn read_existing_config() -> (WranglerConfig, bool) {
     (wrangler_config, exists)
 }
 
-// TODO: Trap ^C and show cursor.
-
 fn main() -> Result<(), std::io::Error> {
     goto_repository_root()?;
     let (cert_pem, issuer_pem) = read_certificates();

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -18,18 +18,23 @@ version = "0.1.0"
 authors = ["9083193+antiphoton@users.noreply.github.com"]
 edition = "2018"
 
+[[bin]]
+name = "gen_sxg"
+required-features = ["rust_signer"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = ["strip_id_headers"]
 rust_signer = []
 strip_id_headers = []
-wasm =[]
+wasm = []
 
 [dependencies]
 anyhow = "1.0.44"
 async-trait = "0.1.51"
 base64 = "0.13.0"
+clap = "3.0.0-beta.4"
 der-parser = { version = "6.0.0", features = ["bigint", "serialize"] }
 futures = { version = "0.3.17", features = ["executor"] }
 getrandom = { version = "0.2.3", features = ["js"] }

--- a/sxg_rs/src/bin/gen_sxg.rs
+++ b/sxg_rs/src/bin/gen_sxg.rs
@@ -1,0 +1,57 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::Clap;
+use futures::executor;
+use std::fs;
+use sxg_rs::{fetcher::NULL_FETCHER, http_cache::NullCache, CreateSignedExchangeParams, SxgWorker};
+
+// TODO: Make this binary generally useful, by documenting the flags and giving them names.
+
+#[derive(Clap)]
+struct Opts {
+    config_yaml: String,
+    cert_pem: String,
+    issuer_pem: String,
+    out_cert_cbor: String,
+    out_sxg: String,
+}
+
+fn main() -> Result<(), std::io::Error> {
+    let opts = Opts::parse();
+    let worker = SxgWorker::new(
+        &fs::read_to_string(opts.config_yaml).unwrap(),
+        &fs::read_to_string(opts.cert_pem).unwrap(),
+        &fs::read_to_string(opts.issuer_pem).unwrap(),
+    )
+    .unwrap();
+    fs::write(opts.out_cert_cbor, &worker.create_cert_cbor(b"ocsp"))?;
+    let payload_headers = worker
+        .transform_payload_headers(vec![("content-type".into(), "text/html".into())])
+        .unwrap();
+    let sxg = worker.create_signed_exchange(CreateSignedExchangeParams {
+        fallback_url: "https://test.example/",
+        cert_origin: "https://test.example",
+        now: std::time::SystemTime::now(),
+        payload_body: b"This is a test.",
+        payload_headers,
+        signer: worker.create_rust_signer().unwrap(),
+        status_code: 200,
+        subresource_fetcher: NULL_FETCHER,
+        header_integrity_cache: NullCache {},
+    });
+    let sxg = executor::block_on(sxg);
+    fs::write(opts.out_sxg, &sxg.unwrap().body)?;
+    Ok(())
+}


### PR DESCRIPTION
Relies on a custom binary to output cert-chain+cbor and SXG. This is an
intermediate step to launching test servers using cloudflare_worker and
fastly_compute.

Addresses #42.