### PR TITLE
Compute 7-day max in Signature.

### DIFF
--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -34,10 +34,11 @@ mod wasm_worker;
 use anyhow::{anyhow, Error, Result};
 use config::Config;
 use fetcher::Fetcher;
-use headers::{AcceptFilter, Headers, BACKDATING};
+use headers::{AcceptFilter, Headers};
 use http::{HeaderFields, HttpResponse};
 use http_cache::HttpCache;
 use serde::Serialize;
+use std::time::Duration;
 use url::Url;
 
 pub struct SxgWorker {
@@ -54,6 +55,11 @@ pub enum PresetContent {
         fallback: HttpResponse,
     },
 }
+
+// To avoid issues with clock skew, backdate the start time by an hour. Don't backdate the
+// expiration because it goes against the origin's cache-control header. (e.g. For max-age
+// <1h, an SXG would be instantly invalid; this would be confusing.)
+const BACKDATING: Duration = Duration::from_secs(60 * 60);
 
 impl SxgWorker {
     pub fn new(config_yaml: &str, cert_pem: &str, issuer_pem: &str) -> Result<SxgWorker> {
@@ -126,14 +132,10 @@ impl SxgWorker {
                 &self.config.validity_url_dirname, "validity"
             ))
             .map_err(|e| Error::new(e).context("Failed to parse validity_url_dirname"))?;
-        // To avoid issues with clock skew, backdate the start time but not the expiration (see
-        // details on the comments in the headers.rs).
-        let expires = now
-            .checked_add(payload_headers.signature_duration()?)
-            .ok_or_else(|| anyhow!("Failed to construct expires"))?;
         let date = now
             .checked_sub(BACKDATING)
             .ok_or_else(|| anyhow!("Failed to construct date"))?;
+        let expires = now.checked_add(payload_headers.signature_duration()?);
         let signature = signature::Signature::new(signature::SignatureParams {
             cert_url: cert_url.as_str(),
             cert_sha256: &self.config.cert_sha256,


### PR DESCRIPTION
This reduces the chance of a future change breaking the requirement, because it
is colocated with comments that reference the signature validity portion of the
spec, and because it is the last possible moment before serialization. This is
a follow-up from the short-term fix in commit 58abde2.

Follow-up to #78.