### PR TITLE
Add convertions to http types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
  "base64 0.13.0",
  "fastly",
  "futures",
+ "http",
  "log 0.4.14",
  "log-fastly",
  "once_cell",
@@ -1639,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -3321,6 +3322,7 @@ dependencies = [
  "der-parser",
  "futures",
  "getrandom 0.2.3",
+ "http",
  "js-sys",
  "nom 7.0.0",
  "once_cell",

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = "0.1.51"
 base64 = "0.13.0"
 fastly = "^0.8.0"
 futures = { version = "0.3.17", features = ["executor"] }
+http = "0.2.5"
 log = "0.4.14"
 log-fastly = "0.8.0"
 once_cell = "1.8.0"

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -38,6 +38,7 @@ clap = "3.0.0-beta.4"
 der-parser = { version = "6.0.0", features = ["bigint", "serialize"] }
 futures = { version = "0.3.17", features = ["executor"] }
 getrandom = { version = "0.2.3", features = ["js"] }
+http = "0.2.5"
 js-sys = "0.3.55"
 nom = { version = "7.0.0", features = ["alloc"] }
 once_cell = "1.8.0"

--- a/sxg_rs/src/http.rs
+++ b/sxg_rs/src/http.rs
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Serializable HTTP interfaces.
+//! # Convertion
+//! For interoperability with other Rust libraries, all structs can be coverted to and from the
+//! corresponding types in [`http`] crate.
+
+use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
+use std::convert::{Infallible, TryFrom, TryInto};
 
 #[derive(Serialize)]
 pub struct HttpRequest {
@@ -22,6 +29,30 @@ pub struct HttpRequest {
     pub url: String,
 }
 
+impl TryFrom<::http::request::Request<Vec<u8>>> for HttpRequest {
+    type Error = Error;
+    fn try_from(input: ::http::request::Request<Vec<u8>>) -> Result<Self> {
+        let (parts, body) = input.into_parts();
+        Ok(HttpRequest {
+            body,
+            headers: try_from_header_map(parts.headers)?,
+            method: parts.method.try_into()?,
+            url: parts.uri.to_string(),
+        })
+    }
+}
+
+impl TryInto<::http::request::Request<Vec<u8>>> for HttpRequest {
+    type Error = Error;
+    fn try_into(self) -> Result<::http::request::Request<Vec<u8>>> {
+        let mut output = ::http::request::Request::new(self.body);
+        *output.headers_mut() = try_into_header_map(self.headers)?;
+        *output.method_mut() = self.method.try_into()?;
+        *output.uri_mut() = self.url.try_into()?;
+        Ok(output)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct HttpResponse {
     pub body: Vec<u8>,
@@ -29,10 +60,88 @@ pub struct HttpResponse {
     pub status: u16,
 }
 
+impl TryFrom<::http::response::Response<Vec<u8>>> for HttpResponse {
+    type Error = Error;
+    fn try_from(input: ::http::response::Response<Vec<u8>>) -> Result<Self> {
+        let (parts, body) = input.into_parts();
+        Ok(HttpResponse {
+            body,
+            headers: try_from_header_map(parts.headers)?,
+            status: parts.status.as_u16(),
+        })
+    }
+}
+
+impl TryInto<::http::response::Response<Vec<u8>>> for HttpResponse {
+    type Error = Error;
+    fn try_into(self) -> Result<::http::response::Response<Vec<u8>>> {
+        let mut output = ::http::response::Response::new(self.body);
+        *output.headers_mut() = try_into_header_map(self.headers)?;
+        *output.status_mut() = self.status.try_into()?;
+        Ok(output)
+    }
+}
+
 pub type HeaderFields = Vec<(String, String)>;
+
+// The more readable way is to write
+// ```
+// impl TryFrom<::http::header::HeaderMap> for HeaderFields { ... }
+// ```
+// But compiler will throw error E0117 if do that.
+// Because `HeaderFields` is a type alias, and we are not the author of `Vec<(String, String)>`.
+fn try_from_header_map(input: ::http::header::HeaderMap) -> Result<HeaderFields> {
+    let mut output = vec![];
+    for (name, value) in input.iter() {
+        let value = value.to_str().map_err(|e| {
+            Error::new(e).context(format!("Header {} contains non-ASCII value", name))
+        })?;
+        output.push((name.to_string(), value.to_string()));
+    }
+    Ok(output)
+}
+
+// The more readable way is to write
+// ```
+// impl TryInto<::http::header::HeaderMap> for HeaderFields { ... }
+// ```
+// But compiler will throw error E0117 if do that.
+// Because `HeaderFields` is a type alias, and we are not the author of `Vec<(String, String)>`.
+fn try_into_header_map(input: HeaderFields) -> Result<::http::header::HeaderMap> {
+    input
+        .iter()
+        .map(|(name, value)| -> Result<_> {
+            let name =
+                ::http::header::HeaderName::from_bytes(name.as_bytes()).map_err(Error::new)?;
+            let value = ::http::header::HeaderValue::from_str(value).map_err(Error::new)?;
+            Ok((name, value))
+        })
+        .collect()
+}
 
 #[derive(Serialize)]
 pub enum Method {
     Get,
     Post,
+}
+
+impl TryFrom<::http::Method> for Method {
+    type Error = Error;
+    fn try_from(method: ::http::Method) -> Result<Self> {
+        match method {
+            ::http::Method::GET => Ok(Method::Get),
+            ::http::Method::POST => Ok(Method::Post),
+            x => Err(anyhow!("Method {} is not supported", x)),
+        }
+    }
+}
+
+impl TryInto<::http::Method> for Method {
+    type Error = Infallible;
+    fn try_into(self) -> Result<::http::Method, Self::Error> {
+        match self {
+            Method::Get => Ok(::http::Method::GET),
+            Method::Post => Ok(::http::Method::POST),
+        }
+    }
 }

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -31,11 +31,11 @@ mod utils;
 #[cfg(feature = "wasm")]
 mod wasm_worker;
 
+use crate::http::{HeaderFields, HttpResponse};
 use anyhow::{anyhow, Error, Result};
 use config::Config;
 use fetcher::Fetcher;
 use headers::{AcceptFilter, Headers};
-use http::{HeaderFields, HttpResponse};
 use http_cache::HttpCache;
 use serde::Serialize;
 use std::time::Duration;


### PR DESCRIPTION
Implement the conversions between `sxg_rs::http::{Request, Response}` and the corresponding structs `::http::{Request, Response}` in the third party [http](https://crates.io/crates/http) crate.

The implementation of `Fetcher` trait is simplified, because most third party libraries are compatible with `http` crate. This applies to struct `FastlyFetcher`, as well as another CLI fetcher in the future when we need to fetch ACME in `config_generator`.

We can't directly use `::http::{Request, Response}` in `sxg_rs` interfaces because the structs in `http` crate are not serializable by serde.