### PR TITLE
Fix `respond_debug_info: true` mode.

### DIFF
--- a/cloudflare_worker/worker/package-lock.json
+++ b/cloudflare_worker/worker/package-lock.json
@@ -235,7 +235,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1136,9 +1135,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
       "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },


### PR DESCRIPTION
- Format Error objects properly (JSON.stringify produces `{}`). TypeScript
  doesn't like me calling `e.toString` on a value of type `unknown`, and none
  of the available narrowing techniques [1] helped, so I opted out of this
  typecheck by annotating with `any` [2]. I didn't find any type that
  would have a problem with this, but I may have missed some. In any case, it
  only occurs when shouldRespondDebugInfo is true, so it won't affect
  production deployments.
- Fetch backend response when the error occurs before fetching, just like
  happens when respond_debug_info is false.

Also, a few unrelated tweaks to make the code more idiomatic (return type
annotation and Elvis operator).

[1] https://www.typescriptlang.org/docs/handbook/2/narrowing.html
[2] https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables