### PR TITLE
Extract an HTMLProcessor interface.

### DIFF
--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -298,9 +298,9 @@ const HTML = /^text\/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$/i;
 
 interface HTMLProcessor {
   register(rewriter: HTMLRewriter): void;
-  // Returns true iff the processor modified the HTML. processHTML uses the
-  // rewritten HTML iff one of the processors returns true. This function
-  // should not have any side-effects; it might not run.
+  // Returns true iff the processor modified the HTML body. processHTML uses
+  // the rewritten HTML body iff one of the processors returns true. This
+  // function should not have any side-effects; it might not run.
   modified(): boolean;
   onEnd(payload: Response): void;
 }


### PR DESCRIPTION
Extracts the <link> tag scraping from promoteLinkTagsToHeaders into an
HTMLProcessor class, renaming the function to processHTML and leaving it to do
the UTF-8 verification and orchestration of given processors.

This improves readability by separating concerns, and will help reduce
duplication in a future commit that processes data-sxg-only attributes.

There is a possible performance regression, though I don't know if it's
significant. In order to accommodate the possibility that an HTMLProcessor
intentionally makes a modification (as will be the case in the future commit),
the processed HTML is buffered rather than discarded as it streams in. But for
the majority of cases where there is no modification, this buffer is a wasted
8MB allocation.

Addresses #87.