### PR TITLE
Fix streams test flake.

### DIFF
--- a/cloudflare_worker/worker/src/streams.test.ts
+++ b/cloudflare_worker/worker/src/streams.test.ts
@@ -31,8 +31,8 @@ describe('readIntoArray', () => {
   });
   it('reads a stream with two chunks', async () => {
     const {writable, readable} = new TransformStream;
-    const writer = writable.getWriter();
     const write = (async() => {
+      const writer = writable.getWriter();
       for (let i = 0; i < 2; i++) {
         await writer.write(new TextEncoder().encode('hello'));
       }
@@ -49,8 +49,8 @@ describe('readIntoArray', () => {
   });
   it('errors if second chunk > maxSize', async () => {
     const {writable, readable} = new TransformStream;
-    const writer = writable.getWriter();
     const write = (async () => {
+      const writer = writable.getWriter();
       for (let i = 0; i < 2; i++) {
         await writer.write(new TextEncoder().encode('hello'));
       }


### PR DESCRIPTION
`writer.close()` was consistently throwing an exception `TypeError: Cannot
close a ERRORED writable stream`. The exception was only sometimes being
noticed by Jasmine because it was not being `await`ed, and thus was falling
back to Jasmine's global detector for unhandled promise rejections. This only
succeeded if the test harness wasn't destructed before the `close()` call
finished.

Changed it not to call `close()` in this case, and to always call `await` to
make future such test issues non-flaky.

Fixes #111.