### PR TITLE
Fix some clippy warnings.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,10 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
+    },
+    {
+      "matchPackageNames": ["wasm-bindgen"],
+      "allowedVersions": "!/^0\\.2\\.79$/"
     }
   ]
 }

--- a/sxg_rs/src/crypto.rs
+++ b/sxg_rs/src/crypto.rs
@@ -36,6 +36,8 @@ pub struct EcPublicKey {
 }
 
 pub struct EcPrivateKey {
+    // Only used when --feature=rust_signer.
+    #[allow(dead_code)]
     d: Vec<u8>,
     pub public_key: EcPublicKey,
 }


### PR DESCRIPTION
Add #[allow(dead_code)] for a field that is only available in feature =
"rust_signer".

Skip wasm-bindgen version 0.2.79 per
https://github.com/rustwasm/wasm-bindgen/issues/2774.