### PR TITLE
Add type annotations to remove Typescript warnings

### DIFF
--- a/cloudflare_worker/worker/package.json
+++ b/cloudflare_worker/worker/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c --failAfterWarnings rollup.config.js",
     "test": "karma start --single-run"
   },
   "dependencies": {},

--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -31,7 +31,7 @@ import {
   WasmRequest,
 } from './wasmFunctions';
 
-addEventListener('fetch', (event) => {
+addEventListener('fetch', (event: FetchEvent) => {
   event.respondWith(handleRequest(event.request))
 })
 
@@ -197,7 +197,7 @@ async function handleRequest(request: Request) {
       fallback = fallwayback;
     }
     if (worker.shouldRespondDebugInfo() && e.toString) {
-      let message = e.toString();
+      let message: string = e.toString();
       return new Response(
         fallback.body,
         {
@@ -406,7 +406,7 @@ async function processHTML(payload: Response, processors: HTMLProcessor[]): Prom
 
 async function generateSxgResponse(fallbackUrl: string, certOrigin: string, payload: Response) {
   let worker = await workerPromise;
-  const payloadHeaders = Array.from(payload.headers);
+  const payloadHeaders: Array<[string, string]> = Array.from(payload.headers);
   worker.validatePayloadHeaders(payloadHeaders);
   const payloadBody = await readIntoArray(payload.body, PAYLOAD_SIZE_LIMIT);
   if (!payloadBody) {

--- a/cloudflare_worker/worker/tsconfig.json
+++ b/cloudflare_worker/worker/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "ESNext",
-    "lib": ["DOM", "ESNext", "WebWorker"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "declaration": true,
     "outDir": "./dist",
     "strict": true,

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -102,7 +102,8 @@ impl WasmWorker {
     ) -> JsPromise {
         let worker = self.0.clone();
         future_to_promise(async move {
-            let payload_headers: Vec<(String, String)> = payload_headers.into_serde().map_err(to_js_error)?;
+            let payload_headers: Vec<(String, String)> =
+                payload_headers.into_serde().map_err(to_js_error)?;
             let payload_headers = worker
                 .transform_payload_headers(payload_headers)
                 .map_err(to_js_error)?;

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -79,7 +79,7 @@ impl WasmWorker {
     }
     #[wasm_bindgen(js_name=validatePayloadHeaders)]
     pub fn validate_payload_headers(&self, fields: JsValue) -> Result<(), JsValue> {
-        let fields = fields.into_serde().map_err(to_js_error)?;
+        let fields: Vec<(String, String)> = fields.into_serde().map_err(to_js_error)?;
         self.0
             .transform_payload_headers(fields)
             .map_err(to_js_error)?;
@@ -102,7 +102,7 @@ impl WasmWorker {
     ) -> JsPromise {
         let worker = self.0.clone();
         future_to_promise(async move {
-            let payload_headers = payload_headers.into_serde().map_err(to_js_error)?;
+            let payload_headers: Vec<(String, String)> = payload_headers.into_serde().map_err(to_js_error)?;
             let payload_headers = worker
                 .transform_payload_headers(payload_headers)
                 .map_err(to_js_error)?;


### PR DESCRIPTION
* Change TypeScript config to match `@cloudflare/workers-types` v3.
* Explicitly write http header fields on FFI as `Vec<(String, String)>` in Rust and `Array<[string, string]>` in TypeScript.
* Set rollup to fail after warnings.

Fixes #135.