### PR TITLE
Update wasm-bindgen to 0.2.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,9 +3901,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3913,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3940,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3950,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3963,9 +3963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"

--- a/cloudflare_worker/Cargo.toml
+++ b/cloudflare_worker/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 console_error_panic_hook = "0.1.7"
 sxg_rs = { path = "../sxg_rs", features = ["wasm"] }
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "0.2.79"
 
 [profile.release]
 opt-level = 3

--- a/cloudflare_worker/src/lib.rs
+++ b/cloudflare_worker/src/lib.rs
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// TODO(antiphoton) No longer allow unused_unit when a new version wasm_bindgen is released with
+// https://github.com/rustwasm/wasm-bindgen/pull/2778
+#![allow(clippy::unused_unit)]
+
 use wasm_bindgen::prelude::wasm_bindgen;
 
 extern crate sxg_rs;

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_yaml = "0.8.21"
 sha2 = "0.9.8"
 url = "2.2.2"
-wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.28"
 web-sys = { version = "0.3.55", features = ["console"] }
 x509-parser = "0.12.0"

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(antiphoton) No longer allow unused_unit when a new version wasm_bindgen is released with
+// https://github.com/rustwasm/wasm-bindgen/pull/2778
+#![allow(clippy::unused_unit)]
+
 use crate::headers::AcceptFilter;
 use crate::http::HttpResponse;
 use crate::utils::to_js_error;


### PR DESCRIPTION
* Update `wasm-bindgen` to latest 0.2.79.

* Allow [unused unit](https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit) warning in clippy. This warning is [introduced](https://github.com/rustwasm/wasm-bindgen/issues/2774) by `wasm-bindgen`. It should be [fixed](https://github.com/rustwasm/wasm-bindgen/pull/2778) in next version of `wasm-bindgen`.