### PR TITLE
Include additional allowed params in Link headers.

### DIFF
--- a/cloudflare_worker/worker/src/utils.test.ts
+++ b/cloudflare_worker/worker/src/utils.test.ts
@@ -16,6 +16,7 @@
 
 import {
   arrayBufferToBase64,
+  escapeLinkParamValue,
 } from './utils';
 
 describe('arrayBufferToBase64', () => {
@@ -23,4 +24,27 @@ describe('arrayBufferToBase64', () => {
     const a = new Uint8Array([1, 2, 3]);
     expect(arrayBufferToBase64(a.buffer)).toEqual('AQID');
   });
-})
+});
+
+describe('escapeLinkParamValue', () => {
+  it('returns tokens as-is', () => {
+    expect(escapeLinkParamValue('hello-world')).toEqual('hello-world');
+  });
+  it('quotes empty string', () => {
+    expect(escapeLinkParamValue('')).toEqual('""');
+  });
+  it('quotes non-tokens', () => {
+    expect(escapeLinkParamValue('hello world')).toEqual('"hello world"');
+  });
+  it('escapes \"', () => {
+    expect(escapeLinkParamValue('hello, "world"'))
+        .toEqual(String.raw`"hello, \"world\""`);
+  });
+  it('escapes \\', () => {
+    expect(escapeLinkParamValue(String.raw`hello\world`))
+        .toEqual(String.raw`"hello\\world"`);
+  });
+  it('returns null for non-representable strings', () => {
+    expect(escapeLinkParamValue('👋🌎')).toEqual(null);
+  });
+});

--- a/cloudflare_worker/worker/src/utils.ts
+++ b/cloudflare_worker/worker/src/utils.ts
@@ -14,8 +14,30 @@
  * limitations under the License.
  */
 
+// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
+export const TOKEN = /^[!#$%&'*+.^_`|~0-9a-zA-Z-]+$/;
+
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const data = Array.from(new Uint8Array(buffer));
   const s = data.map(x => String.fromCharCode(x)).join('');
   return btoa(s);
+}
+
+// Strings representable in a quoted-string, per
+// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6 (including \x22
+// ["] and \x5C [\])..
+const ALLOWED_QUOTED_STRING_VALUE = /^[\t \x21-\x7E]*$/;
+
+// Escapes a value for use as a Link header param, per
+// https://datatracker.ietf.org/doc/html/rfc8288#section-3.
+export function escapeLinkParamValue(value: string): string | null {
+  if (value.match(TOKEN)) {
+    return value;
+  } else if (value.match(ALLOWED_QUOTED_STRING_VALUE)) {
+    return '"' + [...value].map((char) =>
+      (char === '\\' || char === '"') ? '\\' + char : char
+    ).join('') + '"';
+  } else {
+    return null;
+  }
 }


### PR DESCRIPTION
When promoting link tags to headers, include all the parameters allowed by
https://github.com/google/webpackager/blob/main/docs/cache_requirements.md.

This should allow fonts and XHRs to be prefetched, as they require
crossorigin=anonymous.

Addresses #14. See also http://b/220517439.