### PR TITLE
Measure LCP in playground

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sxg-playground",
       "version": "0.1.0",
       "dependencies": {
+        "commander": "^9.0.0",
         "fastify": "3.27.4",
         "node-fetch": "3.2.3",
         "puppeteer": "13.5.1"
@@ -1037,6 +1038,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/commondir": {
@@ -5266,6 +5275,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -21,6 +21,7 @@
     "typescript": "4.6.2"
   },
   "dependencies": {
+    "commander": "^9.0.0",
     "fastify": "3.27.4",
     "node-fetch": "3.2.3",
     "puppeteer": "13.5.1"

--- a/playground/src/client/evaluated.ts
+++ b/playground/src/client/evaluated.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function clickSxgLink() {
+  document.getElementById('sxg-link')!.click();
+}
+
+export function clickNonsxgLink() {
+  document.getElementById('nonsxg-link')!.click();
+}
+
+declare global {
+  interface Window {
+    lcpResult: number | null;
+  }
+}
+
+export function setupObserver() {
+  window.lcpResult = null;
+  const observer = new PerformanceObserver(entryList => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1]!;
+    if (lastEntry.entryType === 'largest-contentful-paint') {
+      window.lcpResult = lastEntry.startTime;
+    }
+  });
+  observer.observe({type: 'largest-contentful-paint', buffered: true});
+}
+
+export function getObserverResult() {
+  return window.lcpResult;
+}

--- a/playground/src/client/evaluated.ts
+++ b/playground/src/client/evaluated.ts
@@ -30,6 +30,10 @@ declare global {
 
 export function setupObserver() {
   window.lcpResult = null;
+  // TODO: Check whether we can use npm package `web-vitals` here.
+  // The `web-vitals` package not only adds the performance observer, but also
+  // [handles](https://github.com/GoogleChrome/web-vitals/blob/ed70ed4b56d3f0573da7ca8ec324e630a04beaf2/src/getLCP.ts#L64-L66)
+  // some user input DOM event.
   const observer = new PerformanceObserver(entryList => {
     const entries = entryList.getEntries();
     const lastEntry = entries[entries.length - 1]!;

--- a/playground/src/client/index.ts
+++ b/playground/src/client/index.ts
@@ -24,7 +24,6 @@ import {
 } from './evaluated';
 
 async function setupPage(page: Page) {
-  await page.setCacheEnabled(false);
   await page.emulate(puppeteer.devices['Pixel 5']!);
   await page.emulateNetworkConditions(puppeteer.networkConditions['Fast 3G']!);
   await page.evaluateOnNewDocument(setupObserver);
@@ -39,7 +38,8 @@ async function measureLcp({
   url: string;
   useSxg: boolean;
 }) {
-  const page = await browser.newPage();
+  const context = await browser.createIncognitoBrowserContext();
+  const page = await context.newPage();
   await setupPage(page);
   page.goto(`https://localhost:8443/srp/${encodeURIComponent(url)}`);
   await page.waitForNavigation({

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -51,8 +51,8 @@ function createSrp(outerUrl: string, innerUrl: string) {
   return `
         <link rel=prefetch href="${outerUrl}">
         <p>${innerUrl}<p>
-        <a href="${outerUrl}">SXG</a>
-        <a href="${innerUrl}">Non-SXG</a>
+        <a id="sxg-link" href="${outerUrl}">SXG</a>
+        <a id="nonsxg-link" href="${innerUrl}">Non-SXG</a>
     `;
 }
 
@@ -69,7 +69,10 @@ strip_response_headers:
   - strict-transport-security
 validity_url_dirname: ".well-known/sxg-validity"
 `;
-export async function startSxgServer({
+
+// Spawns a SXG server that runs in background, and returns a function to stop
+// the server.
+export async function spawnSxgServer({
   certificatePem,
   privateKeyJwk,
   privateKeyPem,
@@ -151,5 +154,8 @@ export async function startSxgServer({
     sxg.headers.forEach(([k, v]) => reply.header(k, v));
     return Buffer.from(sxg.body);
   });
-  fastify.listen(8443, '0.0.0.0', () => {});
+  await fastify.listen(8443, '0.0.0.0');
+  return async function stopServer() {
+    await fastify.close();
+  };
 }


### PR DESCRIPTION
* Use `commander` to parse CLI args
* Add functions, which are evaluated by puppeteer, to collect LCP data.
* Set playground to exit gracefully. The user no longer need to use Ctrl+C to kill the playground.
* Add `id` attributes to links in fake SRP page, making it easier to navigate in puppeteer.