### PR TITLE
Add a command line arg to use browser context in playground

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -35,5 +35,5 @@ A playground to locally preview Signed Exchanges without needing a certificate.
 ## Run
 
 ```
-node dist/index.js https://example.com/
+node dist/index.js --url https://example.com/ --inspect
 ```

--- a/playground/README.md
+++ b/playground/README.md
@@ -34,6 +34,11 @@ A playground to locally preview Signed Exchanges without needing a certificate.
 
 ## Run
 
+```bash
+node dist/index.js --url https://example.com/
 ```
-node dist/index.js --url https://example.com/ --inspect
+The output will be like below, showing SXG decreases LCP from 747ms to 102ms.
+```
+LCP of SXG: 102.2
+LCP of Non-SXG: 747.4
 ```

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -17,7 +17,7 @@
 import {program, Option} from 'commander';
 
 import {createSelfSignedCredentials} from './server/credentials';
-import {runClient} from './client/';
+import {IsolationMode, runClient} from './client/';
 import {spawnSxgServer} from './server/';
 
 async function main() {
@@ -32,6 +32,12 @@ async function main() {
       new Option(
         '--inspect',
         'open a Chrome window and use ChromeDevTools to preview SXG'
+      )
+    )
+    .addOption(
+      new Option(
+        '--isolateBrowserContext',
+        'create a new browser context when testing each URL'
       )
     )
     .addOption(
@@ -53,6 +59,9 @@ async function main() {
     url,
     certificateSpki: publicKeyHash,
     interactivelyInspect: opts['inspect'] ?? false,
+    isolationMode: opts['isolateBrowserContext']
+      ? IsolationMode.IncognitoBrowserContext
+      : IsolationMode.ClearBrowserCache,
     repeatTime: opts['repeatTime'],
   });
   await stopSxgServer();


### PR DESCRIPTION
* `isolationMode` is now a CLI argument.
* Interactive inspecting now also uses new browser context as long as it is requested by `isolationMode`. 