### PR TITLE
Document option for SXG-only subresource preloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ If you write:
 then in an SXG, its inner content will be "unwrapped" out of the template and
 thus activated, and when non-SXG it will be deleted. Since SXGs can't Vary by
 Cookie, this could be used to add lazy-loaded personalization to the SXG, while
-not adding unnecesary bytes to the non-SXG.
+not adding unnecesary bytes to the non-SXG. It could also be used to add
+SXG-only subresource preloads.
 
 ### Preview in Chrome
 


### PR DESCRIPTION
I'm not exactly sure what the use case for this is, yet, but with [Priority Hints](https://web.dev/priority-hints/) landing, I expect there may eventually be diverging use cases for preloads when serving SXG vs non-SXG.

Addresses #153.