### PR TITLE
No longer prefetch SXG in a non-SXG search result page

### DIFF
--- a/playground/src/client/index.ts
+++ b/playground/src/client/index.ts
@@ -29,6 +29,14 @@ async function setupPage(page: Page) {
   await page.evaluateOnNewDocument(setupObserver);
 }
 
+function getSearchResultPageUrl(targetUrl: string, useSxg: boolean) {
+  if (useSxg) {
+    return `https://localhost:8443/srp/${encodeURIComponent(targetUrl)}`;
+  } else {
+    return `https://localhost:8443/nonsxg-srp/${encodeURIComponent(targetUrl)}`;
+  }
+}
+
 // Measures LCP of the given URL in an existing Chrome tab (page).
 async function measureLcp({
   page,
@@ -40,7 +48,7 @@ async function measureLcp({
   useSxg: boolean;
 }) {
   await setupPage(page);
-  page.goto(`https://localhost:8443/srp/${encodeURIComponent(url)}`);
+  page.goto(getSearchResultPageUrl(url, useSxg));
   await page.waitForNavigation({
     waitUntil: 'networkidle0',
   });
@@ -122,7 +130,7 @@ export async function runClient({
       page = await context.newPage();
     }
     await setupPage(page);
-    await page.goto(`https://localhost:8443/srp/${encodeURIComponent(url)}`);
+    await page.goto(getSearchResultPageUrl(url, true));
     await new Promise<void>(resolve => {
       browser.on('disconnected', () => {
         resolve();

--- a/playground/src/server/searchResultPage.ts
+++ b/playground/src/server/searchResultPage.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function createSearchResultPageWithoutSxg(
+  targetInnerUrl: string
+): string {
+  return `
+    <p>Non SXG</p>
+    <a id="nonsxg-link" href="${targetInnerUrl}">${targetInnerUrl}</a>
+  `;
+}
+
+export function createSearchResultPage(
+  targetInnerUrl: string,
+  sxgOuterUrl: string
+): string {
+  return `
+    <p>SXG</p>
+    <a id="sxg-link" href="${sxgOuterUrl}">${targetInnerUrl}</a>
+    <link rel=prefetch href="${sxgOuterUrl}">
+  `;
+}


### PR DESCRIPTION
Split the old function `createSrp` into two an SXG version and a non-SXG version. The new non-SXG search result page does not prefetch SXG.