### PR TITLE
Use lol-html to process HTML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -3075,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3092,9 +3092,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -3763,6 +3763,7 @@ dependencies = [
  "once_cell",
  "p256",
  "pem",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom 0.2.5",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +898,33 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 0.4.7",
+ "matches",
+ "phf",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1021,6 +1065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1193,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03329ae10e79ede66c9ce4dc930aa8599043b0743008548680f25b91502d6"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -1562,6 +1634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1752,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "headers"
@@ -1871,7 +1961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2106,6 +2196,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lol_html"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ff2adf9c54f4de7d66a9177ea7d27d5b8108503bb03d5b719869b8f4bc2ab2"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "cssparser",
+ "encoding_rs",
+ "hashbrown 0.12.0",
+ "lazy_static",
+ "lazycell",
+ "memchr",
+ "safemem",
+ "selectors",
+ "thiserror",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2391,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -2602,6 +2717,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2853,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "predicates"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,6 +2957,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -2844,6 +3026,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3013,6 +3204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,6 +3350,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "matches",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+ "thin-slice",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3472,16 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3460,6 +3690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,6 +3758,7 @@ dependencies = [
  "getrandom 0.2.5",
  "http",
  "js-sys",
+ "lol_html",
  "nom 7.1.1",
  "once_cell",
  "p256",
@@ -3683,6 +3920,12 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -89,12 +89,13 @@ export async function spawnSxgServer({
   );
   const sxgList: WasmResponse[] = [];
   async function createSxgIntoList(innerUrl: string, certOrigin: string) {
-    const sxgPayload = await fetcher({
+    let sxgPayload = await fetcher({
       url: innerUrl,
       body: [],
       method: 'Get',
       headers: [],
     });
+    sxgPayload = worker.processHtml(sxgPayload);
     // TODO(PR#157): Use `handleRequest` function in `cloudflare_worker/worker/src/index.ts`.
     const sxg = await worker.createSignedExchange(
       innerUrl,

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -95,7 +95,7 @@ export async function spawnSxgServer({
       method: 'Get',
       headers: [],
     });
-    sxgPayload = worker.processHtml(sxgPayload);
+    sxgPayload = worker.processHtml(sxgPayload, {isSxg: true});
     // TODO(PR#157): Use `handleRequest` function in `cloudflare_worker/worker/src/index.ts`.
     const sxg = await worker.createSignedExchange(
       innerUrl,

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -43,6 +43,7 @@ nom = { version = "7.1.1", features = ["alloc"] }
 once_cell = "1.10.0"
 p256 = { version = "0.10.1", features = ["ecdsa"] }
 pem = "1.0.2"
+regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -38,6 +38,7 @@ futures = { version = "0.3.21", features = ["executor"] }
 getrandom = { version = "0.2.5", features = ["js"] }
 http = "0.2.6"
 js-sys = "0.3.56"
+lol_html = "0.3.1"
 nom = { version = "7.1.1", features = ["alloc"] }
 once_cell = "1.10.0"
 p256 = { version = "0.10.1", features = ["ecdsa"] }

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -26,6 +26,7 @@ mod id_headers;
 mod link;
 mod mice;
 mod ocsp;
+mod process_html;
 pub mod serde_helpers;
 pub mod signature;
 mod structured_header;
@@ -92,6 +93,9 @@ impl SxgWorker {
     }
     pub fn cert_basename(&self) -> String {
         base64::encode_config(&self.config.cert_sha256, base64::URL_SAFE_NO_PAD)
+    }
+    pub fn process_html(&self, input: HttpResponse) -> Result<HttpResponse> {
+        process_html::process_html(input)
     }
     pub async fn create_signed_exchange<S: signature::Signer, F: Fetcher, C: HttpCache>(
         &self,

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -94,8 +94,12 @@ impl SxgWorker {
     pub fn cert_basename(&self) -> String {
         base64::encode_config(&self.config.cert_sha256, base64::URL_SAFE_NO_PAD)
     }
-    pub fn process_html(&self, input: HttpResponse) -> Result<HttpResponse> {
-        process_html::process_html(input)
+    pub fn process_html(
+        &self,
+        input: HttpResponse,
+        option: process_html::ProcessHtmlOption,
+    ) -> Result<HttpResponse> {
+        process_html::process_html(input, option)
     }
     pub async fn create_signed_exchange<S: signature::Signer, F: Fetcher, C: HttpCache>(
         &self,

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -35,7 +35,7 @@ enum ContentType {
 }
 fn parse_content_type(content_type_header_value: &str) -> ContentType {
     static CONTENT_TYPE_HTML: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r#"^text/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$"#).unwrap());
+        Lazy::new(|| Regex::new(r#"(?i)^text/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$"#).unwrap());
     if let Some(captures) = CONTENT_TYPE_HTML.captures(content_type_header_value) {
         if captures.get(1).is_some() {
             ContentType::HtmlUtf8

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -16,6 +16,8 @@ use crate::http::HttpResponse;
 use crate::http_parser::link::Link;
 use crate::link::ALLOWED_PARAM_NAMES;
 use anyhow::Result;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde::Deserialize;
 use std::borrow::Cow;
 
@@ -25,6 +27,26 @@ pub struct ProcessHtmlOption {
     is_sxg: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum ContentType {
+    HtmlUtf8,
+    HtmlOther,
+    Other,
+}
+fn parse_content_type(content_type_header_value: &str) -> ContentType {
+    static CONTENT_TYPE_HTML: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r#"^text/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$"#).unwrap());
+    if let Some(captures) = CONTENT_TYPE_HTML.captures(content_type_header_value) {
+        if captures.get(1).is_some() {
+            ContentType::HtmlUtf8
+        } else {
+            ContentType::HtmlOther
+        }
+    } else {
+        ContentType::Other
+    }
+}
+
 /// Processes HTML using the following processors.
 /// - For `<link rel=preload>` elements, they are promoted to Link headers.
 /// - For `<template data-sxg-only>` elements:
@@ -32,19 +54,61 @@ pub struct ProcessHtmlOption {
 ///   - Else, they are deleted.
 /// - For `<script data-issxg-var>` elements, they are replaced with
 ///   `<script>window.isSXG=...</script>`, where `...` is true or false.
-/// This function tries the input body as UTF8 string, if input body is not valid UTF8, the input
-/// will be returned back without any HTML processing.
+/// If input charset is not UTF8, the input will be returned back without any HTML.
 pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<HttpResponse> {
+    let content_type_header = input.headers.iter().find_map(|(name, value)| {
+        if name.eq_ignore_ascii_case("content-type") {
+            Some(value)
+        } else {
+            None
+        }
+    });
+    let mut known_utf8 = false;
+    if let Some(content_type_header) = content_type_header {
+        match parse_content_type(content_type_header) {
+            ContentType::HtmlUtf8 => known_utf8 = true,
+            ContentType::HtmlOther => (),
+            ContentType::Other => return Ok(input),
+        };
+    } else {
+        // Doesn't process HTML because content-type header does not exsist.
+        return Ok(input);
+    }
     let input_body = match String::from_utf8(input.body) {
         Ok(input_body) => input_body,
-        Err(e) => return Ok(HttpResponse {
-            body: e.into_bytes(),
-            headers: input.headers,
-            status: input.status,
-        }),
+        Err(e) => {
+            return Ok(HttpResponse {
+                body: e.into_bytes(),
+                headers: input.headers,
+                status: input.status,
+            })
+        }
     };
     let mut link_headers: Vec<String> = vec![];
     let element_content_handlers = vec![
+        // Parse the meta tag, per the implementation in HTMLMetaCharsetParser::CheckForMetaCharset:
+        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/parser/html_meta_charset_parser.cc;l=62-125;drc=7a0b88f6d5c015fd3c280b58c7a99d8e1dca28ac.
+        // This differs slightly from what's described at https://github.com/whatwg/html/issues/6962, and
+        // differs drastically from what's specified in
+        // https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding.
+        lol_html::element!("meta", |e| {
+            // EncodingFromMetaAttributes:
+            // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/parser/html_parser_idioms.cc;l=362-393;drc=7a0b88f6d5c015fd3c280b58c7a99d8e1dca28ac
+            if let Some(charset) = e.get_attribute("charset") {
+                if charset.eq_ignore_ascii_case("utf-8") {
+                    known_utf8 = true;
+                }
+            } else if let (Some(http_equiv), Some(content)) =
+                (e.get_attribute("http-equiv"), e.get_attribute("content"))
+            {
+                if http_equiv.eq_ignore_ascii_case("content-type")
+                    && parse_content_type(&content) == ContentType::HtmlUtf8
+                {
+                    known_utf8 = true;
+                }
+            }
+            Ok(())
+        }),
         lol_html::element!(
             r#"link[rel~="preload" i][href][as]:not([data-sxg-no-header])"#,
             |e| {
@@ -91,6 +155,13 @@ pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<Ht
             ..lol_html::Settings::default()
         },
     )?;
+    if !known_utf8 {
+        return Ok(HttpResponse {
+            headers: input.headers,
+            status: input.status,
+            body: input_body.into_bytes(),
+        });
+    }
     let mut output_headers = input.headers;
     output_headers.push(("Link".to_string(), link_headers.join(",")));
     Ok(HttpResponse {
@@ -98,4 +169,71 @@ pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<Ht
         headers: output_headers,
         status: input.status,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn it_parses_content_type() {
+        assert_eq!(parse_content_type(r#"text/html"#), ContentType::HtmlOther);
+        assert_eq!(
+            parse_content_type(r#"text/html; charset=utf-8"#),
+            ContentType::HtmlUtf8
+        );
+        assert_eq!(
+            parse_content_type(r#"text/html; charset="utf-8""#),
+            ContentType::HtmlUtf8
+        );
+        assert_eq!(parse_content_type(r#"text/plain"#), ContentType::Other);
+    }
+    fn quick_process(content_type: &str, input_body: &str) -> String {
+        let output = process_html(
+            HttpResponse {
+                status: 200,
+                headers: vec![("content-type".to_string(), content_type.to_string())],
+                body: input_body.to_string().into_bytes(),
+            },
+            ProcessHtmlOption { is_sxg: true },
+        );
+        String::from_utf8(output.unwrap().body).unwrap()
+    }
+    #[test]
+    fn it_works() {
+        assert_eq!(
+            quick_process(
+                "text/html;charset=utf-8",
+                "<script data-issxg-var></script>",
+            ),
+            "<script data-issxg-var>window.isSXG=true</script>"
+        );
+        // HTML is not processed when charset is not specified.
+        assert_eq!(
+            quick_process("text/html", "<script data-issxg-var></script>",),
+            "<script data-issxg-var></script>",
+        );
+        // Meta tag of charset is supported.
+        assert_eq!(
+            quick_process(
+                "text/html",
+                "<meta http-equiv=content-type content=\"text/html;charset=utf-8\">\
+                <script data-issxg-var></script>"
+            ),
+            "<meta http-equiv=content-type content=\"text/html;charset=utf-8\">\
+            <script data-issxg-var>window.isSXG=true</script>"
+        );
+        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/parser/html_parser_idioms.cc;l=308-354;drc=984c3018ecb2ff818e900fdb7c743fc00caf7efe
+        // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#extracting-character-encodings-from-meta-elements
+        // lol-html doesn't appear to decode HTML entities inside
+        // attribute values, so this won't work. This could be supported in the future.
+        assert_eq!(
+            quick_process(
+                "text/html",
+                "<meta http-equiv=content-type content=\"text/html;charset=&quot;utf-8&quot;\">\
+                <script data-issxg-var></script>"
+            ),
+            "<meta http-equiv=content-type content=\"text/html;charset=&quot;utf-8&quot;\">\
+            <script data-issxg-var></script>",
+        );
+    }
 }

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -77,12 +77,13 @@ pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<Ht
     let input_body = match String::from_utf8(input.body) {
         Ok(input_body) => input_body,
         Err(e) => {
-            // Doesn't process HTML because input body bytes can't be parsed at UTF-8 string.
+            // Doesn't process HTML because input body bytes can't be parsed at UTF-8 string, for
+            // example, a UTF-16 BOM exsists.
             return Ok(HttpResponse {
                 body: e.into_bytes(),
                 headers: input.headers,
                 status: input.status,
-            })
+            });
         }
     };
     let mut link_headers: Vec<String> = vec![];

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -77,6 +77,7 @@ pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<Ht
     let input_body = match String::from_utf8(input.body) {
         Ok(input_body) => input_body,
         Err(e) => {
+            // Doesn't process HTML because input body bytes can't be parsed at UTF-8 string.
             return Ok(HttpResponse {
                 body: e.into_bytes(),
                 headers: input.headers,

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,53 +14,68 @@
 
 use crate::http::HttpResponse;
 use crate::http_parser::link::Link;
+use crate::link::ALLOWED_PARAM_NAMES;
 use anyhow::Result;
-use once_cell::sync::Lazy;
+use serde::Deserialize;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
-static ALLOWED_LINK_ATTRS: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
-    vec![
-        "as",
-        "header-integrity",
-        "media",
-        "rel",
-        "imagesrcset",
-        "imagesizes",
-        "crossorigin",
-    ]
-    .into_iter()
-    .collect()
-});
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessHtmlOption {
+    is_sxg: bool,
+}
 
-pub fn process_html(input: HttpResponse) -> Result<HttpResponse> {
+/// Processes HTML using the following processors.
+/// - For `<link rel=preload>` elements, they are promoted to Link headers.
+/// - For `<template data-sxg-only>` elements:
+///   - If SXG, they are "unwrapped" (i.e. their children promoted out of the <teplate>).
+///   - Else, they are deleted.
+/// - For `<script data-issxg-var>` elements, they are replaced with
+///   `<script>window.isSXG=...</script>`, where `...` is true or false.
+/// This function assumes the input document to be encoded in UTF8. It is needed to ensure that the
+/// document is explicitly labellbed as UTF8 via ContentType of <meta> before using this function.
+pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<HttpResponse> {
     let mut link_headers: Vec<String> = vec![];
-    let element_content_handlers = vec![lol_html::element!(
-        r#"link[rel~="preload" i][href][as]:not([data-sxg-no-header])"#,
-        |e| {
-            if let Some(href) = e.get_attribute("href") {
-                let params: Vec<(Cow<'static, str>, Option<String>)> = e
-                    .attributes()
-                    .iter()
-                    .filter_map(|attr| {
-                        let name = attr.name();
-                        let value = attr.value();
-                        if ALLOWED_LINK_ATTRS.contains(name.as_str()) {
-                            Some((Cow::Owned(name), Some(value)))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                let link = Link {
-                    uri: href.to_string(),
-                    params,
-                };
-                link_headers.push(link.serialize());
+    let element_content_handlers = vec![
+        lol_html::element!(
+            r#"link[rel~="preload" i][href][as]:not([data-sxg-no-header])"#,
+            |e| {
+                if let Some(href) = e.get_attribute("href") {
+                    let params: Vec<(Cow<'static, str>, Option<String>)> = e
+                        .attributes()
+                        .iter()
+                        .filter_map(|attr| {
+                            let name = attr.name();
+                            let value = attr.value();
+                            if ALLOWED_PARAM_NAMES.contains(name.as_str()) {
+                                Some((Cow::Owned(name), Some(value)))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    let link = Link { uri: href, params };
+                    link_headers.push(link.serialize());
+                }
+                Ok(())
+            }
+        ),
+        lol_html::element!(r#"script[data-issxg-var]"#, |e| {
+            e.set_inner_content(
+                &format!("window.isSXG={}", option.is_sxg),
+                lol_html::html_content::ContentType::Html,
+            );
+            Ok(())
+        }),
+        lol_html::element!(r#"template[data-sxg-only]"#, |e| {
+            if option.is_sxg {
+                e.remove_and_keep_content()
+            } else {
+                e.remove()
             }
             Ok(())
-        }
-    )];
+        }),
+    ];
     let input_body = String::from_utf8(input.body)?;
     let output = lol_html::rewrite_str(
         &input_body,

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! This file is the Rust implementation of
+//! [processor.ts](https://github.com/google/sxg-rs/blob/main/typescript_utilities/src/processor.ts).
+//! Most of the context of why and how we process HTML are documented in that file.
+
 use crate::http::HttpResponse;
 use crate::http_parser::link::Link;
 use crate::link::ALLOWED_PARAM_NAMES;

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -1,0 +1,79 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::http::HttpResponse;
+use crate::http_parser::link::Link;
+use anyhow::Result;
+use once_cell::sync::Lazy;
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+
+static ALLOWED_LINK_ATTRS: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
+    vec![
+        "as",
+        "header-integrity",
+        "media",
+        "rel",
+        "imagesrcset",
+        "imagesizes",
+        "crossorigin",
+    ]
+    .into_iter()
+    .collect()
+});
+
+pub fn process_html(input: HttpResponse) -> Result<HttpResponse> {
+    let mut link_headers: Vec<String> = vec![];
+    let element_content_handlers = vec![lol_html::element!(
+        r#"link[rel~="preload" i][href][as]:not([data-sxg-no-header])"#,
+        |e| {
+            if let Some(href) = e.get_attribute("href") {
+                let params: Vec<(Cow<'static, str>, Option<String>)> = e
+                    .attributes()
+                    .iter()
+                    .filter_map(|attr| {
+                        let name = attr.name();
+                        let value = attr.value();
+                        if ALLOWED_LINK_ATTRS.contains(name.as_str()) {
+                            Some((Cow::Owned(name), Some(value)))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let link = Link {
+                    uri: href.to_string(),
+                    params,
+                };
+                link_headers.push(link.serialize());
+            }
+            Ok(())
+        }
+    )];
+    let input_body = String::from_utf8(input.body)?;
+    let output = lol_html::rewrite_str(
+        &input_body,
+        lol_html::Settings {
+            element_content_handlers,
+            ..lol_html::Settings::default()
+        },
+    )?;
+    let mut output_headers = input.headers;
+    output_headers.push(("Link".to_string(), link_headers.join(",")));
+    Ok(HttpResponse {
+        body: output.into_bytes(),
+        headers: output_headers,
+        status: input.status,
+    })
+}

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -54,7 +54,7 @@ fn parse_content_type(content_type_header_value: &str) -> ContentType {
 ///   - Else, they are deleted.
 /// - For `<script data-issxg-var>` elements, they are replaced with
 ///   `<script>window.isSXG=...</script>`, where `...` is true or false.
-/// If input charset is not UTF8, the input will be returned back without any HTML.
+/// If input charset is not UTF8, the input will be returned back without any modification.
 pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> Result<HttpResponse> {
     let content_type_header = input.headers.iter().find_map(|(name, value)| {
         if name.eq_ignore_ascii_case("content-type") {

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -38,8 +38,9 @@ enum ContentType {
     Other,
 }
 fn parse_content_type(content_type_header_value: &str) -> ContentType {
-    static CONTENT_TYPE_HTML: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r#"(?i)^text/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$"#).unwrap());
+    static CONTENT_TYPE_HTML: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r#"(?i)^text/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$"#).unwrap()
+    });
     if let Some(captures) = CONTENT_TYPE_HTML.captures(content_type_header_value) {
         if captures.get(1).is_some() {
             ContentType::HtmlUtf8

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -89,6 +89,12 @@ impl WasmWorker {
             .map_err(to_js_error)?;
         Ok(())
     }
+    #[wasm_bindgen(js_name=processHtml)]
+    pub fn process_html(&self, input: JsValue) -> Result<JsValue, JsValue> {
+        let input: HttpResponse = input.into_serde().map_err(to_js_error)?;
+        let output = self.0.process_html(input).map_err(to_js_error)?;
+        JsValue::from_serde(&output).map_err(to_js_error)
+    }
     #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen(js_name=createSignedExchange)]
     pub fn create_signed_exchange(

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -18,6 +18,7 @@
 
 use crate::headers::AcceptFilter;
 use crate::http::HttpResponse;
+use crate::process_html::ProcessHtmlOption;
 use crate::utils::to_js_error;
 use crate::SxgWorker;
 use anyhow::Result;
@@ -90,9 +91,10 @@ impl WasmWorker {
         Ok(())
     }
     #[wasm_bindgen(js_name=processHtml)]
-    pub fn process_html(&self, input: JsValue) -> Result<JsValue, JsValue> {
+    pub fn process_html(&self, input: JsValue, option: JsValue) -> Result<JsValue, JsValue> {
         let input: HttpResponse = input.into_serde().map_err(to_js_error)?;
-        let output = self.0.process_html(input).map_err(to_js_error)?;
+        let option: ProcessHtmlOption = option.into_serde().map_err(to_js_error)?;
+        let output = self.0.process_html(input, option).map_err(to_js_error)?;
         JsValue::from_serde(&output).map_err(to_js_error)
     }
     #[allow(clippy::too_many_arguments)]

--- a/typescript_utilities/src/processor.ts
+++ b/typescript_utilities/src/processor.ts
@@ -218,6 +218,7 @@ export class PromoteLinkTagsToHeaders implements HTMLProcessor {
         const as = link.getAttribute('as');
         // Ensure the values can be placed inside a Link header without
         // escaping or quoting.
+        // TODO: matching `as` against `TOKEN` is no longer needed
         if (href?.match(URL_CHARS) && as?.match(TOKEN)) {
           // link.attributes is somehow being mistyped as an Attr[], per the
           // definition of Attr from typescript/lib/lib.dom.d.ts. Not sure why;

--- a/typescript_utilities/src/processor.ts
+++ b/typescript_utilities/src/processor.ts
@@ -49,6 +49,9 @@ const ALLOWED_LINK_ATTRS = new Set([
   'crossorigin',
 ]);
 
+// This logic is duplicated in `/sxg_rs/src/process_html.rs`, and any chages in
+// `HTMLProcessor` and `processHTML` need to be replicated over there.
+// TODO: Use `process_html.rs` to do everything.
 interface HTMLProcessor {
   register(rewriter: HTMLRewriter): void;
   // Returns true iff the processor modified the HTML body. processHTML uses
@@ -65,8 +68,6 @@ interface HTMLProcessor {
 //
 // For `<meta name=declare-issxg-var>` elements, they are replaced with
 // `<script>window.isSXG=...</script>`, where `...` is true or false.
-
-// TODO: Use Rust `process_html.rs` to do this.
 export class SXGOnly {
   isSXG: boolean;
   modified = false;
@@ -207,7 +208,6 @@ export async function processHTML(
 // If any <link rel=preload>s are found, they are promoted to Link headers.
 // Later, generateSxgResponse will further modify the link header to support
 // SXG preloading of eligible subresources.
-// TODO: Use Rust `process_html.rs` to do this.
 export class PromoteLinkTagsToHeaders implements HTMLProcessor {
   modified = false;
   link_tags: {href: string; attrs: string[][]}[] = [];

--- a/typescript_utilities/src/processor.ts
+++ b/typescript_utilities/src/processor.ts
@@ -65,6 +65,8 @@ interface HTMLProcessor {
 //
 // For `<meta name=declare-issxg-var>` elements, they are replaced with
 // `<script>window.isSXG=...</script>`, where `...` is true or false.
+
+// TODO: Use Rust `process_html.rs` to do this.
 export class SXGOnly {
   isSXG: boolean;
   modified = false;
@@ -205,6 +207,7 @@ export async function processHTML(
 // If any <link rel=preload>s are found, they are promoted to Link headers.
 // Later, generateSxgResponse will further modify the link header to support
 // SXG preloading of eligible subresources.
+// TODO: Use Rust `process_html.rs` to do this.
 export class PromoteLinkTagsToHeaders implements HTMLProcessor {
   modified = false;
   link_tags: {href: string; attrs: string[][]}[] = [];

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -52,6 +52,10 @@ export type PresetContent =
       fallback: WasmResponse;
     };
 
+export interface ProcessHtmlOption {
+  isSxg: boolean;
+}
+
 export interface WasmWorker {
   // eslint-disable-next-line @typescript-eslint/no-misused-new
   new (configYaml: string, certPem: string, issuerPem: string): WasmWorker;
@@ -59,7 +63,7 @@ export interface WasmWorker {
     accept_filter: AcceptFilter,
     fields: HeaderFields
   ): HeaderFields;
-  processHtml(input: WasmResponse): WasmResponse;
+  processHtml(input: WasmResponse, option: ProcessHtmlOption): WasmResponse;
   createSignedExchange(
     fallbackUrl: string,
     certOrigin: string,

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -59,6 +59,7 @@ export interface WasmWorker {
     accept_filter: AcceptFilter,
     fields: HeaderFields
   ): HeaderFields;
+  processHtml(input: WasmResponse): WasmResponse;
   createSignedExchange(
     fallbackUrl: string,
     certOrigin: string,


### PR DESCRIPTION
- Use `lol-html` to implement `process_html`, which 
  - Promotes `<link>` tags to HTTP headers.
  - Rewrites `<template data-sxg-only>` and `<script data-issxg-var>`.
- Call Rust version `process_html` in playground.