### PR TITLE
Make header methods and config public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target/
 
 **/*.rs.bk
+.log
+.vscode
+.idea
+.DS_store

--- a/sxg_rs/src/config.rs
+++ b/sxg_rs/src/config.rs
@@ -40,7 +40,7 @@ pub struct ConfigInput {
 // This contains not only source-of-truth ConfigInput, but also a few more
 // attributes which are computed from ConfigInput.
 pub struct Config {
-    input: ConfigInput,
+    pub input: ConfigInput,
     pub cert_der: Vec<u8>,
     pub cert_sha256: Vec<u8>,
     pub issuer_der: Vec<u8>,

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -43,7 +43,7 @@ pub enum AcceptFilter {
 const USER_AGENT: &str = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36";
 
 impl Headers {
-    pub(crate) fn new(data: HeaderFields, strip_headers: &BTreeSet<String>) -> Self {
+    pub fn new(data: HeaderFields, strip_headers: &BTreeSet<String>) -> Self {
         let mut headers = Headers(HashMap::new());
         for (mut k, v) in data {
             k.make_ascii_lowercase();
@@ -53,7 +53,7 @@ impl Headers {
         }
         headers
     }
-    pub(crate) fn forward_to_origin_server(
+    pub fn forward_to_origin_server(
         self,
         accept_filter: AcceptFilter,
         forwarded_header_names: &BTreeSet<String>,
@@ -97,7 +97,7 @@ impl Headers {
         }
         Ok(new_headers.into_iter().collect())
     }
-    pub(crate) fn validate_as_sxg_payload(&self) -> Result<()> {
+    pub fn validate_as_sxg_payload(&self) -> Result<()> {
         for (k, v) in self.0.iter() {
             if DONT_SIGN_RESPONSE_HEADERS.contains(k.as_str()) {
                 return Err(anyhow!(r#"A stateful header "{}" is found."#, k));
@@ -204,7 +204,7 @@ impl Headers {
         fields.push(("digest", &digest));
         serializer(fields)
     }
-    pub(crate) async fn get_signed_headers_bytes(
+    pub async fn get_signed_headers_bytes(
         &self,
         fallback_url: &Url,
         status_code: u16,
@@ -250,7 +250,7 @@ impl Headers {
         }
     }
     // How long the signature should last, or error if the response shouldn't be signed.
-    pub(crate) fn signature_duration(&self) -> Result<Duration> {
+    pub fn signature_duration(&self) -> Result<Duration> {
         // Default to 7 days unless a cache-control directive lowers it.
         // Only look at the most specific cache-control header present. This follows the requirement
         // in https://datatracker.ietf.org/doc/html/draft-cdn-control-header-01#section-2.1.

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -45,7 +45,7 @@ use std::time::Duration;
 use url::Url;
 
 pub struct SxgWorker {
-    config: Config,
+    pub config: Config,
 }
 
 #[derive(Serialize, Debug, PartialEq)]


### PR DESCRIPTION
The PR proposes to make the config and helper methods inside `Headers` public. The current SxgWorker requires user to gather all certificates before hand. However, it may not be the case when a system stores certificates elsewhere or want to construct SxgWorker dynamically.