### PR TITLE
Add playground options to set user agent and emulation option

### DIFF
--- a/playground/src/client/emulationOptions.ts
+++ b/playground/src/client/emulationOptions.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const NOT_EMULATED = 'none';
+
+export interface EmulationOptions {
+  device: string;
+  networkCondition: string,
+}

--- a/playground/src/client/emulationOptions.ts
+++ b/playground/src/client/emulationOptions.ts
@@ -18,5 +18,5 @@ export const NOT_EMULATED = 'none';
 
 export interface EmulationOptions {
   device: string;
-  networkCondition: string,
+  networkCondition: string;
 }

--- a/playground/src/client/index.ts
+++ b/playground/src/client/index.ts
@@ -16,10 +16,7 @@
 
 import puppeteer, {Browser} from 'puppeteer';
 import {Page} from 'puppeteer';
-import {
-  EmulationOptions,
-  NOT_EMULATED,
-} from './emulationOptions';
+import {EmulationOptions, NOT_EMULATED} from './emulationOptions';
 import {
   clickSearchResultLink,
   setupObserver,
@@ -27,15 +24,14 @@ import {
 } from './evaluated';
 
 async function setupPage(page: Page, emulationOptions: EmulationOptions) {
-  const {
-    device,
-    networkCondition,
-  } = emulationOptions;
+  const {device, networkCondition} = emulationOptions;
   if (device !== NOT_EMULATED) {
     await page.emulate(puppeteer.devices[device]!);
   }
   if (networkCondition !== NOT_EMULATED) {
-    await page.emulateNetworkConditions(puppeteer.networkConditions[networkCondition]!);
+    await page.emulateNetworkConditions(
+      puppeteer.networkConditions[networkCondition]!
+    );
   }
   await page.evaluateOnNewDocument(setupObserver);
 }
@@ -56,7 +52,7 @@ async function measureLcp({
   useSxg,
 }: {
   page: Page;
-  emulationOptions: EmulationOptions,
+  emulationOptions: EmulationOptions;
   url: string;
   useSxg: boolean;
 }) {
@@ -92,7 +88,7 @@ async function createPageAndMeasureLcp({
 }: {
   browser: Browser;
   isolationMode: IsolationMode;
-  emulationOptions: EmulationOptions,
+  emulationOptions: EmulationOptions;
   url: string;
   useSxg: boolean;
 }) {
@@ -126,7 +122,7 @@ export async function runClient({
   certificateSpki: string;
   interactivelyInspect: boolean;
   isolationMode: IsolationMode;
-  emulationOptions: EmulationOptions,
+  emulationOptions: EmulationOptions;
   repeatTime: number;
   url: string;
 }) {

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -24,6 +24,13 @@ async function main() {
   program
     .addOption(
       new Option(
+        '--crawler-user-agent <string>',
+        'the user-agent request header to be sent to the website server'
+        // The defalt value is from https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers#googlebot-smartphone
+      ).default(`Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`)
+    )
+    .addOption(
+      new Option(
         '--url <url>',
         'A single URL to be measured'
       ).makeOptionMandatory(true)
@@ -52,6 +59,7 @@ async function main() {
     await createSelfSignedCredentials(new URL(opts['url']).hostname);
   const stopSxgServer = await spawnSxgServer({
     certificatePem,
+    crawlerUserAgent: opts['crawlerUserAgent'],
     privateKeyJwk,
     privateKeyPem,
   });

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -17,9 +17,7 @@
 import {program, Option} from 'commander';
 
 import {IsolationMode, runClient} from './client/';
-import {
-  NOT_EMULATED,
-} from './client/emulationOptions';
+import {NOT_EMULATED} from './client/emulationOptions';
 import {createSelfSignedCredentials} from './server/credentials';
 import {spawnSxgServer} from './server/';
 
@@ -30,19 +28,25 @@ async function main() {
         '--crawler-user-agent <string>',
         'The user-agent request header to be sent to the website server'
         // The defalt value is from https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers#googlebot-smartphone
-      ).default(`Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`)
+      ).default(
+        'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+      )
     )
     .addOption(
       new Option(
         '--emulate-device <string>',
         'The device that puppeteer emulates'
-      ).choices(['Pixel 5', 'iPhone XR', NOT_EMULATED]).default(`Pixel 5`)
+      )
+        .choices(['Pixel 5', 'iPhone XR', NOT_EMULATED])
+        .default('Pixel 5')
     )
     .addOption(
       new Option(
         '--emulate-network <string>',
         'The network condition that puppeteer emulates'
-      ).choices(['Slow 3G', 'Fast 3G', NOT_EMULATED]).default(`Pixel 5`)
+      )
+        .choices(['Slow 3G', 'Fast 3G', NOT_EMULATED])
+        .default('Pixel 5')
     )
     .addOption(
       new Option(
@@ -54,13 +58,13 @@ async function main() {
       new Option(
         '--inspect',
         'open a Chrome window and use ChromeDevTools to preview SXG'
-      )
+      ).default(false)
     )
     .addOption(
       new Option(
         '--isolateBrowserContext',
         'create a new browser context when testing each URL'
-      )
+      ).default(false)
     )
     .addOption(
       new Option('--repeat-time <number>', 'measure LCP multiple times')
@@ -68,28 +72,35 @@ async function main() {
         .default(1)
     );
   program.parse();
-  const opts = program.opts();
-  const url: string = opts['url'];
+  const opts = program.opts() as {
+    crawlerUserAgent: string;
+    emulateDevice: string;
+    emulateNetwork: string;
+    inspect: boolean;
+    isolateBrowserContext: boolean;
+    repeatTime: number;
+    url: string;
+  };
   const {certificatePem, privateKeyJwk, privateKeyPem, publicKeyHash} =
-    await createSelfSignedCredentials(new URL(opts['url']).hostname);
+    await createSelfSignedCredentials(new URL(opts.url).hostname);
   const stopSxgServer = await spawnSxgServer({
     certificatePem,
-    crawlerUserAgent: opts['crawlerUserAgent'],
+    crawlerUserAgent: opts.crawlerUserAgent,
     privateKeyJwk,
     privateKeyPem,
   });
   await runClient({
-    url,
+    url: opts.url,
     certificateSpki: publicKeyHash,
-    interactivelyInspect: opts['inspect'] ?? false,
+    interactivelyInspect: opts.inspect,
     emulationOptions: {
-      device: opts['emulateDevice'],
-      networkCondition: opts['emulateNetwork']
+      device: opts.emulateDevice,
+      networkCondition: opts.emulateNetwork,
     },
-    isolationMode: opts['isolateBrowserContext']
+    isolationMode: opts.isolateBrowserContext
       ? IsolationMode.IncognitoBrowserContext
       : IsolationMode.ClearBrowserCache,
-    repeatTime: opts['repeatTime'],
+    repeatTime: opts.repeatTime,
   });
   await stopSxgServer();
 }

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -16,8 +16,11 @@
 
 import {program, Option} from 'commander';
 
-import {createSelfSignedCredentials} from './server/credentials';
 import {IsolationMode, runClient} from './client/';
+import {
+  NOT_EMULATED,
+} from './client/emulationOptions';
+import {createSelfSignedCredentials} from './server/credentials';
 import {spawnSxgServer} from './server/';
 
 async function main() {
@@ -25,9 +28,21 @@ async function main() {
     .addOption(
       new Option(
         '--crawler-user-agent <string>',
-        'the user-agent request header to be sent to the website server'
+        'The user-agent request header to be sent to the website server'
         // The defalt value is from https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers#googlebot-smartphone
       ).default(`Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`)
+    )
+    .addOption(
+      new Option(
+        '--emulate-device <string>',
+        'The device that puppeteer emulates'
+      ).choices(['Pixel 5', 'iPhone XR', NOT_EMULATED]).default(`Pixel 5`)
+    )
+    .addOption(
+      new Option(
+        '--emulate-network <string>',
+        'The network condition that puppeteer emulates'
+      ).choices(['Slow 3G', 'Fast 3G', NOT_EMULATED]).default(`Pixel 5`)
     )
     .addOption(
       new Option(
@@ -67,6 +82,10 @@ async function main() {
     url,
     certificateSpki: publicKeyHash,
     interactivelyInspect: opts['inspect'] ?? false,
+    emulationOptions: {
+      device: opts['emulateDevice'],
+      networkCondition: opts['emulateNetwork']
+    },
     isolationMode: opts['isolateBrowserContext']
       ? IsolationMode.IncognitoBrowserContext
       : IsolationMode.ClearBrowserCache,

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -60,10 +60,12 @@ validity_url_dirname: ".well-known/sxg-validity"
 // the server.
 export async function spawnSxgServer({
   certificatePem,
+  crawlerUserAgent,
   privateKeyJwk,
   privateKeyPem,
 }: {
   certificatePem: string;
+  crawlerUserAgent: string;
   privateKeyJwk: Object;
   privateKeyPem: string;
 }) {
@@ -92,7 +94,9 @@ export async function spawnSxgServer({
       url: innerUrl,
       body: [],
       method: 'Get',
-      headers: [],
+      headers: [
+        ['user-agent', crawlerUserAgent],
+      ],
     });
     sxgPayload = worker.processHtml(sxgPayload, {isSxg: true});
     const urlRecorder = subresourceCache.createRecorder();

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -94,9 +94,7 @@ export async function spawnSxgServer({
       url: innerUrl,
       body: [],
       method: 'Get',
-      headers: [
-        ['user-agent', crawlerUserAgent],
-      ],
+      headers: [['user-agent', crawlerUserAgent]],
     });
     sxgPayload = worker.processHtml(sxgPayload, {isSxg: true});
     const urlRecorder = subresourceCache.createRecorder();


### PR DESCRIPTION
Add command line option to playground to set
1. `user-agent` request headers to be sent to original server
2. device screen size for puppeteer
3. network conditions of puppeteer