### PR TITLE
Join duplicate headers into one

### DIFF
--- a/sxg_rs/src/acme/jws.rs
+++ b/sxg_rs/src/acme/jws.rs
@@ -119,9 +119,10 @@ impl JsonWebSignature {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     #[async_std::test]
+    #[cfg(feature = "rust_signer")]
     async fn json_web_signature() {
+        use super::*;
         // This test follow the example given in RFC 7515.
         // https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.3.1
         let protected_header = r#"{"alg":"ES256"}"#;


### PR DESCRIPTION
`Headers::new` will join duplicate headers into one, using comma to separate values.

Minor fix to run tests without --all-features flag.


Close #202 