### PR TITLE
Use base64 for debugging response body

### DIFF
--- a/sxg_rs/src/http.rs
+++ b/sxg_rs/src/http.rs
@@ -53,7 +53,7 @@ impl TryInto<::http::request::Request<Vec<u8>>> for HttpRequest {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
 pub struct HttpResponse {
     pub body: Vec<u8>,
     pub headers: HeaderFields,
@@ -143,5 +143,15 @@ impl TryInto<::http::Method> for Method {
             Method::Get => Ok(::http::Method::GET),
             Method::Post => Ok(::http::Method::POST),
         }
+    }
+}
+
+impl std::fmt::Debug for HttpResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpResponse")
+            .field("status", &self.status)
+            .field("headers", &self.headers)
+            .field("body", &base64::encode(&self.body))
+            .finish()
     }
 }


### PR DESCRIPTION
Change [Debug](https://doc.rust-lang.org/std/fmt/trait.Debug.html) implementation of `HttpResponse` to show `body` in base64 string, making it easier to debug a large response body.

For example, `println!("{:#?}", response);` shows
* before this PR
  ```
  HttpResponse {
    status: 200,
    headers: [],
    body: [
      72,
      101,
      108,
      108,
      111,
      32,
      119,
      111,
      114,
      108,
      100,
      33
    ]
  }
  ```
* after this PR 
  ```
  HttpResponse {
    status: 200,
    headers: [],
    body: "SGVsbG8gd29ybGQh"
  }
  ```
