### PR TITLE
Use an example domain for playground certificate

### DIFF
--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -82,7 +82,7 @@ async function main() {
     url: string;
   };
   const {certificatePem, privateKeyJwk, privateKeyPem, publicKeyHash} =
-    await createSelfSignedCredentials(new URL(opts.url).hostname);
+    await createSelfSignedCredentials('example.com');
   const stopSxgServer = await spawnSxgServer({
     certificatePem,
     crawlerUserAgent: opts.crawlerUserAgent,


### PR DESCRIPTION
Use `example.com` for all self-signed certificates.

Using `example.com` does not break the playground because puppeteer always trusts the self-signed certificates and does not check the domain.