### PR TITLE
Simplify content-type header parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,7 +3609,6 @@ dependencies = [
  "once_cell",
  "p256",
  "pem",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -43,7 +43,6 @@ nom = { version = "7.1.1", features = ["alloc"] }
 once_cell = "1.10.0"
 p256 = { version = "0.10.1", features = ["ecdsa"] }
 pem = "1.0.2"
-regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -20,8 +20,6 @@ use crate::http::HttpResponse;
 use crate::http_parser::link::Link;
 use crate::link::ALLOWED_PARAM_NAMES;
 use anyhow::Result;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::Deserialize;
 use std::borrow::Cow;
 
@@ -38,11 +36,9 @@ enum ContentType {
     Other,
 }
 fn parse_content_type(content_type_header_value: &str) -> ContentType {
-    static CONTENT_TYPE_HTML: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r#"(?i)^text/html([ \t]*;[ \t]*charset=(utf-8|"utf-8"))?$"#).unwrap()
-    });
-    if let Some(captures) = CONTENT_TYPE_HTML.captures(content_type_header_value) {
-        if captures.get(1).is_some() {
+    let content_type_header_value = content_type_header_value.trim().to_ascii_lowercase();
+    if content_type_header_value.starts_with("text/html") {
+        if content_type_header_value.contains("utf-8") {
             ContentType::HtmlUtf8
         } else {
             ContentType::HtmlOther
@@ -240,7 +236,7 @@ mod tests {
                 <script data-issxg-var></script>"
             ),
             "<meta http-equiv=content-type content=\"text/html;charset=&quot;utf-8&quot;\">\
-            <script data-issxg-var></script>",
+            <script data-issxg-var>window.isSXG=true</script>",
         );
     }
 }

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -36,7 +36,7 @@ enum ContentType {
     Other,
 }
 fn parse_content_type(content_type_header_value: &str) -> ContentType {
-    let content_type_header_value = content_type_header_value.trim().to_ascii_lowercase();
+    let content_type_header_value = content_type_header_value.trim_start().to_ascii_lowercase();
     if content_type_header_value.starts_with("text/html") {
         if content_type_header_value.contains("utf-8") {
             ContentType::HtmlUtf8
@@ -188,6 +188,10 @@ mod tests {
             parse_content_type(r#"text/html; charset="utf-8""#),
             ContentType::HtmlUtf8
         );
+        assert_eq!(
+            parse_content_type(r#"text/html; charset=ascii"#),
+            ContentType::HtmlOther
+        );
         assert_eq!(parse_content_type(r#"text/plain"#), ContentType::Other);
     }
     fn quick_process(content_type: &str, input_body: &str) -> String {
@@ -225,10 +229,7 @@ mod tests {
             "<meta http-equiv=content-type content=\"text/html;charset=utf-8\">\
             <script data-issxg-var>window.isSXG=true</script>"
         );
-        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/parser/html_parser_idioms.cc;l=308-354;drc=984c3018ecb2ff818e900fdb7c743fc00caf7efe
-        // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#extracting-character-encodings-from-meta-elements
-        // lol-html doesn't appear to decode HTML entities inside
-        // attribute values, so this won't work. This could be supported in the future.
+        // Meta tag with HTML-encoded attribute
         assert_eq!(
             quick_process(
                 "text/html",


### PR DESCRIPTION
We can safely assume the value of content-type follows convention and remove regex dependency (this could save ~100kb). The pull request simplifies the the regex matching to dumb string matches. 

* Only html document [starts with `text/html` in its mime-type](https://www.iana.org/assignments/media-types/media-types.xhtml)
* If it is `text/html` then [it should have `charset` directive only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type). So we can directly look for `utf-8`

Note: I think [the current regex pattern](https://github.com/google/sxg-rs/blob/34f19080a6e3bdab2273e9cfab7daa7c525e5c9a/sxg_rs/src/process_html.rs#L42) does not match `text/html;charset=non-utf-8`