### PR TITLE
Add a CLI param to use multiple URLs in playground

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -116,4 +116,4 @@ jobs:
         run: |
           npm install
           npm run build
-          node dist/index.js --url https://example.com/
+          node dist/index.js --single-url https://example.com/

--- a/playground/README.md
+++ b/playground/README.md
@@ -36,10 +36,11 @@ A playground to locally preview Signed Exchanges without needing a certificate.
 ## Run
 
 ```bash
-node dist/index.js --url https://example.com/
+node dist/index.js --single-url https://example.com/ --emulate-network Fast\ 3G
 ```
 The output will be like below, showing SXG decreases LCP from 747ms to 102ms.
 ```
+Starting to measure https://example.com
 LCP of SXG: 102.2
 LCP of Non-SXG: 747.4
 ```


### PR DESCRIPTION
* Add `--url-list` CLI param, to measure LCP of multiple URLs.
* Split the old `runClient` function into two new functions `runInteractiveClient` (for `inspect === true` and `runBatchClient` (for `inspect === false`).