### PR TITLE
Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.3.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
+checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
 
 [[package]]
 name = "billboard"
@@ -3483,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
  "digest 0.9.0",
  "rand_core 0.6.3",
@@ -3585,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sxg_rs"
@@ -3598,7 +3598,6 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
- "clap 3.1.8",
  "der-parser",
  "futures",
  "getrandom 0.2.6",

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2018"
 
 [features]
 default = ["strip_id_headers"]
-rust_signer = []
+rust_signer = ["p256"]
 srcset = []
 strip_id_headers = []
 wasm = []
@@ -31,7 +31,6 @@ wasm = []
 anyhow = "1.0.56"
 async-trait = "0.1.53"
 base64 = "0.13.0"
-clap = { version = "3.1.8", features = ["derive"] }
 chrono = { version = "0.4.19", features = ["serde"] }
 der-parser = { version = "7.0.0", features = ["bigint", "serialize"] }
 futures = { version = "0.3.21", features = ["executor"] }
@@ -41,8 +40,8 @@ js-sys = "0.3.57"
 lol_html = "0.3.1"
 nom = { version = "7.1.1", features = ["alloc"] }
 once_cell = "1.10.0"
-p256 = { version = "0.10.1", features = ["ecdsa"] }
 pem = "1.0.2"
+p256 = { version = "0.10.1", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"


### PR DESCRIPTION
* sxg-rs (the library) doesn't depend on clap
* p256 is used only when using rust_signer feature