### PR TITLE
Fix default parameter of network throttling

### DIFF
--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -47,7 +47,7 @@ async function main() {
         'The network condition that puppeteer emulates'
       )
         .choices(['Slow 3G', 'Fast 3G', NOT_EMULATED])
-        .default('Pixel 5')
+        .default(NOT_EMULATED)
     )
     .addOption(
       new Option('--single-url <url>', 'A single URL to be measured').conflicts(


### PR DESCRIPTION
Fix the default CLI parameter for network throttling in playground.
The code behavior before this PR also worked without any issue, because `"Pixel 5"` is not a network, and puppeteer always ignore it.