### PR TITLE
Make process_link_header step optional

### DIFF
--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -243,20 +243,20 @@ async function generateSxgResponse(
   }
   const {get: headerIntegrityGet, put: headerIntegrityPut} =
     await headerIntegrityCache();
-  const now_in_seconds = Math.floor(Date.now() / 1000);
-  const sxg = await worker.createSignedExchange(
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const sxg = await worker.createSignedExchange({
     fallbackUrl,
     certOrigin,
-    payload.status,
+    statusCode: payload.status,
     payloadHeaders,
     payloadBody,
-    true,
-    now_in_seconds,
+    skipProcessLink: false,
+    nowInSeconds,
     signer,
-    fetcher,
+    subresourceFetcher: fetcher,
     headerIntegrityGet,
-    headerIntegrityPut
-  );
+    headerIntegrityPut,
+  });
   return responseFromWasm(sxg);
 }
 

--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -250,6 +250,7 @@ async function generateSxgResponse(
     payload.status,
     payloadHeaders,
     payloadBody,
+    true,
     now_in_seconds,
     signer,
     fetcher,

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -104,6 +104,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
         now: std::time::SystemTime::now(),
         payload_body: &payload_body,
         payload_headers,
+        process_link: true,
         signer,
         status_code: 200,
         fallback_url: fallback_url.as_str(),

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -104,7 +104,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
         now: std::time::SystemTime::now(),
         payload_body: &payload_body,
         payload_headers,
-        process_link: true,
+        skip_process_link: true,
         signer,
         status_code: 200,
         fallback_url: fallback_url.as_str(),

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -104,7 +104,7 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
         now: std::time::SystemTime::now(),
         payload_body: &payload_body,
         payload_headers,
-        skip_process_link: true,
+        skip_process_link: false,
         signer,
         status_code: 200,
         fallback_url: fallback_url.as_str(),

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -101,19 +101,19 @@ export async function spawnSxgServer({
     sxgPayload = worker.processHtml(sxgPayload, {isSxg: true});
     const urlRecorder = subresourceCache.createRecorder();
     // TODO(PR#157): Use `handleRequest` function in `cloudflare_worker/worker/src/index.ts`.
-    const sxg = await worker.createSignedExchange(
-      innerUrl,
+    const sxg = await worker.createSignedExchange({
+      fallbackUrl: innerUrl,
       certOrigin,
-      sxgPayload.status,
-      sxgPayload.headers,
-      new Uint8Array(sxgPayload.body),
-      true,
-      Date.now() / 1000,
+      statusCode: sxgPayload.status,
+      payloadHeaders: sxgPayload.headers,
+      payloadBody: new Uint8Array(sxgPayload.body),
+      skipProcessLink: false,
+      nowInSeconds: Date.now() / 1000,
       signer,
-      fetcher,
-      urlRecorder.get,
-      urlRecorder.put
-    );
+      subresourceFetcher: fetcher,
+      headerIntegrityGet: urlRecorder.get,
+      headerIntegrityPut: urlRecorder.put,
+    });
     const subresourceUrls = isTopLevel
       ? Array.from(urlRecorder.visitedUrls())
       : [];

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -107,6 +107,7 @@ export async function spawnSxgServer({
       sxgPayload.status,
       sxgPayload.headers,
       new Uint8Array(sxgPayload.body),
+      true,
       Date.now() / 1000,
       signer,
       fetcher,

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -27,6 +27,9 @@ srcset = []
 strip_id_headers = []
 wasm = []
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 anyhow = "1.0.56"
 async-trait = "0.1.53"

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -134,14 +134,14 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcherImpl<'a, F, C> {
             Url::parse(url).map_err(|e| Error::new(e).context("parsing fallback URL"))?;
         // TODO: Figure out how to reduce the amount of data cloned.
         let payload_headers = Headers::new(response.headers.clone(), self.strip_response_headers);
+        let mut header_integrity_fetcher =
+            new_fetcher(NULL_FETCHER, NullCache, self.strip_response_headers);
         let (signed_headers, _) = signed_headers_and_payload(
             &fallback_base,
             response.status,
             &payload_headers,
             &response.body,
-            NULL_FETCHER,
-            NullCache {},
-            self.strip_response_headers,
+            &mut header_integrity_fetcher,
             process_link,
         )
         .await?;

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -66,7 +66,7 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcher for HeaderIntegrityFet
             _ => {
                 let response = match self.fetch_subresource(url).await {
                     Ok(response) => {
-                        match self.compute_integrity(url, &response, false).await {
+                        match self.compute_integrity(url, &response, true).await {
                             Ok(integrity) => {
                                 // Keep original cache-control headers, so the integrity is
                                 // up-to-date with the subresource.
@@ -128,7 +128,7 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcherImpl<'a, F, C> {
         &self,
         url: &str,
         response: &HttpResponse,
-        process_link: bool,
+        skip_process_link: bool,
     ) -> Result<Vec<u8>> {
         let fallback_base =
             Url::parse(url).map_err(|e| Error::new(e).context("parsing fallback URL"))?;
@@ -142,7 +142,7 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcherImpl<'a, F, C> {
             &payload_headers,
             &response.body,
             &mut header_integrity_fetcher,
-            process_link,
+            skip_process_link,
         )
         .await?;
         Ok([

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -187,16 +187,15 @@ impl Headers {
                      Ok(MediaType {primary_type, sub_type, ..})
                          if primary_type.eq_ignore_ascii_case("text") && sub_type.eq_ignore_ascii_case("html")));
         let link;
-        if process_link {
-            link = match self.0.get("link") {
-                Some(value) => {
-                    process_link_header(value, fallback_url, header_integrity_fetcher).await
+        match (process_link, self.0.get("link")) {
+            (true, Some(value)) => {
+                link = process_link_header(value, fallback_url, header_integrity_fetcher).await;
+                if !link.is_empty() {
+                    fields.push(("link", &link));
                 }
-                None => "".into(),
-            };
-            if !link.is_empty() {
-                fields.push(("link", &link));
             }
+            (false, Some(value)) if !value.is_empty() => fields.push(("link", value)),
+            _ => (),
         }
         for (k, v) in self.0.iter() {
             if STRIP_RESPONSE_HEADERS.contains(k.as_str())

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -120,6 +120,7 @@ impl SxgWorker {
             now,
             payload_body,
             payload_headers,
+            process_link,
             signer,
             status_code,
             subresource_fetcher,
@@ -145,6 +146,7 @@ impl SxgWorker {
             subresource_fetcher,
             header_integrity_cache,
             &self.config.strip_response_headers,
+            process_link,
         )
         .await?;
         let cert_url = cert_base
@@ -341,6 +343,7 @@ pub struct CreateSignedExchangeParams<'a, S: signature::Signer, F: Fetcher, C: H
     pub now: std::time::SystemTime,
     pub payload_body: &'a [u8],
     pub payload_headers: headers::Headers,
+    pub process_link: bool,
     pub signer: S,
     pub status_code: u16,
     pub subresource_fetcher: F,

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -120,7 +120,7 @@ impl SxgWorker {
             now,
             payload_body,
             payload_headers,
-            process_link,
+            skip_process_link,
             signer,
             status_code,
             subresource_fetcher,
@@ -149,7 +149,7 @@ impl SxgWorker {
             &payload_headers,
             payload_body,
             &mut header_integrity_fetcher,
-            process_link,
+            skip_process_link,
         )
         .await?;
         let cert_url = cert_base
@@ -346,7 +346,7 @@ pub struct CreateSignedExchangeParams<'a, S: signature::Signer, F: Fetcher, C: H
     pub now: std::time::SystemTime,
     pub payload_body: &'a [u8],
     pub payload_headers: headers::Headers,
-    pub process_link: bool,
+    pub skip_process_link: bool,
     pub signer: S,
     pub status_code: u16,
     pub subresource_fetcher: F,

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -138,14 +138,17 @@ impl SxgWorker {
             .map_err(|e| Error::new(e).context("Failed to parse fallback URL"))?;
         let cert_base = Url::parse(cert_origin)
             .map_err(|e| Error::new(e).context("Failed to parse cert origin"))?;
+        let mut header_integrity_fetcher = header_integrity::new_fetcher(
+            subresource_fetcher,
+            header_integrity_cache,
+            &self.config.strip_response_headers,
+        );
         let (signed_headers, payload_body) = utils::signed_headers_and_payload(
             &fallback_base,
             status_code,
             &payload_headers,
             payload_body,
-            subresource_fetcher,
-            header_integrity_cache,
-            &self.config.strip_response_headers,
+            &mut header_integrity_fetcher,
             process_link,
         )
         .await?;

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -71,6 +71,7 @@ pub async fn signed_headers_and_payload<F: Fetcher, C: HttpCache>(
     subresource_fetcher: F,
     header_integrity_cache: C,
     strip_response_headers: &BTreeSet<String>,
+    process_link: bool,
 ) -> Result<(Vec<u8>, Vec<u8>)> {
     if status_code != 200 {
         return Err(anyhow!("The resource status code is {}.", status_code));
@@ -89,6 +90,7 @@ pub async fn signed_headers_and_payload<F: Fetcher, C: HttpCache>(
             status_code,
             &mice_digest,
             &mut header_integrity_fetcher,
+            process_link,
         )
         .await;
     Ok((signed_headers, payload_body))

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -67,7 +67,7 @@ pub async fn signed_headers_and_payload(
     payload_headers: &Headers,
     payload_body: &[u8],
     header_integrity_fetcher: &mut dyn HeaderIntegrityFetcher,
-    process_link: bool,
+    skip_process_link: bool,
 ) -> Result<(Vec<u8>, Vec<u8>)> {
     if status_code != 200 {
         return Err(anyhow!("The resource status code is {}.", status_code));
@@ -81,7 +81,7 @@ pub async fn signed_headers_and_payload(
             status_code,
             &mice_digest,
             header_integrity_fetcher,
-            process_link,
+            skip_process_link,
         )
         .await;
     Ok((signed_headers, payload_body))

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::fetcher::Fetcher;
-use crate::header_integrity;
+use crate::header_integrity::HeaderIntegrityFetcher;
 use crate::headers::Headers;
-use crate::http_cache::HttpCache;
 use anyhow::{anyhow, Result};
-use std::collections::BTreeSet;
 use url::Url;
 
 #[cfg(all(target_family = "wasm", feature = "wasm"))]
@@ -63,14 +60,13 @@ pub fn to_js_error<E: std::fmt::Debug>(e: E) -> wasm_bindgen::JsValue {
     wasm_bindgen::JsValue::from_str(&format!("{:?}", e))
 }
 
-pub async fn signed_headers_and_payload<F: Fetcher, C: HttpCache>(
+// #[warn(clippy::too_many_arguments)]
+pub async fn signed_headers_and_payload(
     fallback_url: &Url,
     status_code: u16,
     payload_headers: &Headers,
     payload_body: &[u8],
-    subresource_fetcher: F,
-    header_integrity_cache: C,
-    strip_response_headers: &BTreeSet<String>,
+    header_integrity_fetcher: &mut dyn HeaderIntegrityFetcher,
     process_link: bool,
 ) -> Result<(Vec<u8>, Vec<u8>)> {
     if status_code != 200 {
@@ -79,17 +75,12 @@ pub async fn signed_headers_and_payload<F: Fetcher, C: HttpCache>(
     // 16384 is the max mice record size allowed by SXG spec.
     // https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#section-3.5-7.9.1
     let (mice_digest, payload_body) = crate::mice::calculate(payload_body, 16384);
-    let mut header_integrity_fetcher = header_integrity::new_fetcher(
-        subresource_fetcher,
-        header_integrity_cache,
-        strip_response_headers,
-    );
     let signed_headers = payload_headers
         .get_signed_headers_bytes(
             fallback_url,
             status_code,
             &mice_digest,
-            &mut header_integrity_fetcher,
+            header_integrity_fetcher,
             process_link,
         )
         .await;

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -106,6 +106,7 @@ impl WasmWorker {
         status_code: u16,
         payload_headers: JsValue,
         payload_body: Vec<u8>,
+        process_link: bool,
         now_in_seconds: u32,
         signer: JsFunction,
         subresource_fetcher: JsFunction,
@@ -138,6 +139,7 @@ impl WasmWorker {
                     status_code,
                     subresource_fetcher,
                     header_integrity_cache,
+                    process_link,
                 })
                 .await
                 .map_err(to_js_error)?;

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -106,7 +106,7 @@ impl WasmWorker {
         status_code: u16,
         payload_headers: JsValue,
         payload_body: Vec<u8>,
-        process_link: bool,
+        skip_process_link: bool,
         now_in_seconds: u32,
         signer: JsFunction,
         subresource_fetcher: JsFunction,
@@ -139,7 +139,7 @@ impl WasmWorker {
                     status_code,
                     subresource_fetcher,
                     header_integrity_cache,
-                    process_link,
+                    skip_process_link,
                 })
                 .await
                 .map_err(to_js_error)?;

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -33,6 +33,33 @@ use wasm_bindgen_futures::future_to_promise;
 pub struct WasmWorker(Arc<SxgWorker>);
 
 #[wasm_bindgen]
+extern "C" {
+    pub type CreateSignedExchangedOptions;
+    #[wasm_bindgen(method, getter, js_name = "fallbackUrl")]
+    fn fallback_url(this: &CreateSignedExchangedOptions) -> String;
+    #[wasm_bindgen(method, getter, js_name = "certOrigin")]
+    fn cert_origin(this: &CreateSignedExchangedOptions) -> String;
+    #[wasm_bindgen(method, getter, js_name = "statusCode")]
+    fn status_code(this: &CreateSignedExchangedOptions) -> u16;
+    #[wasm_bindgen(method, getter, js_name = "payloadHeaders")]
+    fn payload_headers(this: &CreateSignedExchangedOptions) -> JsValue;
+    #[wasm_bindgen(method, getter, js_name = "payloadBody")]
+    fn payload_body(this: &CreateSignedExchangedOptions) -> Vec<u8>;
+    #[wasm_bindgen(method, getter, js_name = "skipProcessLink")]
+    fn skip_process_link(this: &CreateSignedExchangedOptions) -> bool;
+    #[wasm_bindgen(method, getter, js_name = "nowInSeconds")]
+    fn now_in_seconds(this: &CreateSignedExchangedOptions) -> u32;
+    #[wasm_bindgen(method, getter, js_name = "signer")]
+    fn signer(this: &CreateSignedExchangedOptions) -> JsFunction;
+    #[wasm_bindgen(method, getter, js_name = "subresourceFetcher")]
+    fn subresource_fetcher(this: &CreateSignedExchangedOptions) -> JsFunction;
+    #[wasm_bindgen(method, getter, js_name = "headerIntegrityGet")]
+    fn header_integrity_get(this: &CreateSignedExchangedOptions) -> JsFunction;
+    #[wasm_bindgen(method, getter, js_name = "headerIntegrityPut")]
+    fn header_integrity_put(this: &CreateSignedExchangedOptions) -> JsFunction;
+}
+
+#[wasm_bindgen]
 impl WasmWorker {
     #[wasm_bindgen(constructor)]
     pub fn new(config_yaml: &str, cert_pem: &str, issuer_pem: &str) -> Result<WasmWorker, JsValue> {
@@ -97,49 +124,37 @@ impl WasmWorker {
         let output = self.0.process_html(input, option).map_err(to_js_error)?;
         JsValue::from_serde(&output).map_err(to_js_error)
     }
-    #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen(js_name=createSignedExchange)]
-    pub fn create_signed_exchange(
-        &self,
-        fallback_url: String,
-        cert_origin: String,
-        status_code: u16,
-        payload_headers: JsValue,
-        payload_body: Vec<u8>,
-        skip_process_link: bool,
-        now_in_seconds: u32,
-        signer: JsFunction,
-        subresource_fetcher: JsFunction,
-        header_integrity_get: JsFunction,
-        header_integrity_put: JsFunction,
-    ) -> JsPromise {
+    pub fn create_signed_exchange(&self, options: CreateSignedExchangedOptions) -> JsPromise {
         let worker = self.0.clone();
         future_to_promise(async move {
-            let payload_headers: Vec<(String, String)> =
-                payload_headers.into_serde().map_err(to_js_error)?;
+            let payload_headers: Vec<(String, String)> = options
+                .payload_headers()
+                .into_serde()
+                .map_err(to_js_error)?;
             let payload_headers = worker
                 .transform_payload_headers(payload_headers)
                 .map_err(to_js_error)?;
-            let signer = crate::signature::js_signer::JsSigner::from_raw_signer(signer);
+            let signer = crate::signature::js_signer::JsSigner::from_raw_signer(options.signer());
             let subresource_fetcher =
-                crate::fetcher::js_fetcher::JsFetcher::new(subresource_fetcher);
+                crate::fetcher::js_fetcher::JsFetcher::new(options.subresource_fetcher());
             let header_integrity_cache = crate::http_cache::js_http_cache::JsHttpCache {
-                get: header_integrity_get,
-                put: header_integrity_put,
+                get: options.header_integrity_get(),
+                put: options.header_integrity_put(),
             };
             let sxg: HttpResponse = worker
                 .create_signed_exchange(crate::CreateSignedExchangeParams {
-                    fallback_url: &fallback_url,
-                    cert_origin: &cert_origin,
+                    fallback_url: &options.fallback_url(),
+                    cert_origin: &options.cert_origin(),
                     now: std::time::UNIX_EPOCH
-                        + std::time::Duration::from_secs(now_in_seconds as u64),
-                    payload_body: &payload_body,
+                        + std::time::Duration::from_secs(options.now_in_seconds() as u64),
+                    payload_body: &options.payload_body(),
                     payload_headers,
                     signer,
-                    status_code,
+                    status_code: options.status_code(),
                     subresource_fetcher,
                     header_integrity_cache,
-                    skip_process_link,
+                    skip_process_link: options.skip_process_link(),
                 })
                 .await
                 .map_err(to_js_error)?;

--- a/tools/src/gen_sxg.rs
+++ b/tools/src/gen_sxg.rs
@@ -46,6 +46,7 @@ pub fn main(opts: Opts) -> Result<()> {
         now: std::time::SystemTime::now(),
         payload_body: b"This is a test.",
         payload_headers,
+        process_link: true,
         signer: worker.create_rust_signer().unwrap(),
         status_code: 200,
         subresource_fetcher: NULL_FETCHER,

--- a/tools/src/gen_sxg.rs
+++ b/tools/src/gen_sxg.rs
@@ -46,7 +46,7 @@ pub fn main(opts: Opts) -> Result<()> {
         now: std::time::SystemTime::now(),
         payload_body: b"This is a test.",
         payload_headers,
-        process_link: true,
+        skip_process_link: false,
         signer: worker.create_rust_signer().unwrap(),
         status_code: 200,
         subresource_fetcher: NULL_FETCHER,

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -70,6 +70,7 @@ export interface WasmWorker {
     statusCode: number,
     payloadHeaders: HeaderFields,
     payloadBody: Uint8Array,
+    process_link: boolean,
     nowInSeconds: number,
     signer: (input: Uint8Array) => Promise<Uint8Array>,
     subresourceFetcher: (request: WasmRequest) => Promise<WasmResponse>,

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -52,6 +52,20 @@ export type PresetContent =
       fallback: WasmResponse;
     };
 
+export type CreateSignedExchangedOptions = {
+  fallbackUrl: string;
+  certOrigin: string;
+  statusCode: number;
+  payloadHeaders: HeaderFields;
+  payloadBody: Uint8Array;
+  skipProcessLink: boolean;
+  nowInSeconds: number;
+  signer: (input: Uint8Array) => Promise<Uint8Array>;
+  subresourceFetcher: (request: WasmRequest) => Promise<WasmResponse>;
+  headerIntegrityGet: (url: string) => Promise<WasmResponse>;
+  headerIntegrityPut: (url: string, response: WasmResponse) => Promise<void>;
+};
+
 export interface ProcessHtmlOption {
   isSxg: boolean;
 }
@@ -64,19 +78,7 @@ export interface WasmWorker {
     fields: HeaderFields
   ): HeaderFields;
   processHtml(input: WasmResponse, option: ProcessHtmlOption): WasmResponse;
-  createSignedExchange(
-    fallbackUrl: string,
-    certOrigin: string,
-    statusCode: number,
-    payloadHeaders: HeaderFields,
-    payloadBody: Uint8Array,
-    process_link: boolean,
-    nowInSeconds: number,
-    signer: (input: Uint8Array) => Promise<Uint8Array>,
-    subresourceFetcher: (request: WasmRequest) => Promise<WasmResponse>,
-    headerIntegrityGet: (url: string) => Promise<WasmResponse>,
-    headerIntegrityPut: (url: string, response: WasmResponse) => Promise<void>
-  ): WasmResponse;
+  createSignedExchange(options: CreateSignedExchangedOptions): WasmResponse;
   fetchOcspFromCa(
     fetcher: (request: WasmRequest) => Promise<WasmResponse>
   ): Uint8Array;


### PR DESCRIPTION
Per [Google AMP Cache requirements](https://github.com/ampproject/amppackager/blob/releases/docs/cache_requirements.md) and [SXG cache requirements](https://github.com/google/webpackager/blob/main/docs/cache_requirements.md), it should be possible to use `sxg-rs` for both. However, the specs for `link` header in AMP SXG cache is different from SXG cache. We can just make this step optional so `sxg-rs` could be used for AMP SXG too.