### PR TITLE
Allow signer to return different formats

### DIFF
--- a/sxg_rs/src/signature/mock_signer.rs
+++ b/sxg_rs/src/signature/mock_signer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Signer;
+use super::{Format, Signer};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -20,7 +20,10 @@ pub struct MockSigner;
 
 #[async_trait(?Send)]
 impl Signer for MockSigner {
-    async fn sign(&self, _message: &[u8]) -> Result<Vec<u8>> {
-        super::raw_sig_to_asn1([0].repeat(64))
+    async fn sign(&self, _message: &[u8], format: Format) -> Result<Vec<u8>> {
+        match format {
+            Format::EccAsn1 => super::raw_sig_to_asn1([0].repeat(64)),
+            Format::Raw => Ok([0].repeat(64)),
+        }
     }
 }

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Signer;
+use super::{Format, Signer};
 use anyhow::Result;
 use async_trait::async_trait;
 use p256::ecdsa::SigningKey;
@@ -30,9 +30,12 @@ impl RustSigner {
 
 #[async_trait(?Send)]
 impl Signer for RustSigner {
-    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+    async fn sign(&self, message: &[u8], format: Format) -> Result<Vec<u8>> {
         use p256::ecdsa::signature::Signer as _;
-        let sig = self.private_key.try_sign(message)?.to_der();
-        Ok(sig.as_bytes().to_vec())
+        let sig = self.private_key.try_sign(message)?;
+        match format {
+            Format::Raw => Ok(sig.to_vec()),
+            Format::EccAsn1 => Ok(sig.to_der().as_bytes().to_vec()),
+        }
     }
 }


### PR DESCRIPTION
* Move `parse_asn1_sig` from `acme/jws.rs` to `signature/mod.rs`.
* Add a second parameter `format` to the `sign` method, so that the caller can select which format they need from `Signer`. 
  Previously, the `sign` method always returns `asn1` format, which is used in SXG. However, ACME does not use `asn1` format.
  * `signer.sign(m)` is now changed to `signer.sign(m, EccAsn1)`.
  * `parse_asn1_sig(signer.sign(m))` is now changed to `signer.sign(m, Raw)`
