### PR TITLE
Add External Account Binding for ACME

### DIFF
--- a/sxg_rs/src/acme/directory.rs
+++ b/sxg_rs/src/acme/directory.rs
@@ -30,7 +30,10 @@ pub struct Directory {
     pub new_order: String,
     pub new_authz: Option<String>,
     pub revoke_cert: String,
-    pub key_change: String,
+    // Although `key_change` is a required field, we are not using it.
+    // We are marking it an optional field here, so we don't throw errors if
+    // the ACME server does not provide it.
+    pub key_change: Option<String>,
     pub meta: MetaData,
 }
 

--- a/sxg_rs/src/acme/eab.rs
+++ b/sxg_rs/src/acme/eab.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module implements External Account Binding (EAB), which is defined in
+//! [RFC-8555](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4).
+
+use super::jws::JsonWebSignature;
+use crate::crypto::EcPublicKey;
+use crate::signature::Signer;
+use anyhow::Result;
+use serde::Serialize;
+
+/// The protected header which is used for External Account Binding.
+#[derive(Serialize)]
+struct EabProtectedHeader<'a> {
+    /// Signing algorithm used by EAB, with
+    /// [possible values](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).
+    alg: &'a str,
+    /// Key identifier from Certificate Authority.
+    kid: &'a str,
+    /// URL of the request. This is usually the new-account URL of ACME server,
+    /// because only new-account requests need EAB.
+    url: &'a str,
+}
+
+pub async fn create_external_account_binding<S: Signer>(
+    alg: &str,
+    kid: &str,
+    url: &str,
+    public_key: &EcPublicKey,
+    signer: &S,
+) -> Result<JsonWebSignature> {
+    let protected_header = EabProtectedHeader { alg, kid, url };
+    JsonWebSignature::new(protected_header, /*payload=*/ Some(public_key), signer).await
+}

--- a/sxg_rs/src/acme/jws.rs
+++ b/sxg_rs/src/acme/jws.rs
@@ -65,7 +65,7 @@ impl JsonWebSignature {
     /// Constructs a signature from serialiable header and payload.
     /// If the given `payload` is `None`, it will be serialized into an empty
     /// string.
-    async fn new<H: Serialize, P: Serialize, S: Signer>(
+    pub async fn new<H: Serialize, P: Serialize, S: Signer>(
         protected_header: H,
         payload: Option<P>,
         signer: &S,

--- a/sxg_rs/src/acme/mod.rs
+++ b/sxg_rs/src/acme/mod.rs
@@ -22,6 +22,7 @@
 
 pub mod client;
 pub mod directory;
+pub mod eab;
 pub mod jws;
 
 use crate::crypto::EcPublicKey;

--- a/tools/src/linux_commands.rs
+++ b/tools/src/linux_commands.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// Executes a command, and returns the stdout as bytes.
-fn execute(command: &mut Command) -> Result<Vec<u8>> {
+pub fn execute(command: &mut Command) -> Result<Vec<u8>> {
     let output = command
         .output()
         .map_err(|e| Error::new(e).context("Failed to execute command"))?;
@@ -25,7 +25,7 @@ fn execute(command: &mut Command) -> Result<Vec<u8>> {
 }
 
 /// Executes a command, and parses the stdout as a string.
-fn execute_and_parse_stdout(command: &mut Command) -> Result<String> {
+pub fn execute_and_parse_stdout(command: &mut Command) -> Result<String> {
     let stdout = execute(command)?;
     String::from_utf8(stdout)
         .map_err(|e| Error::new(e).context("The stdout contains non-utf8 bytes."))

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -18,6 +18,7 @@ mod gen_dev_cert;
 mod gen_sxg;
 mod hyper_fetcher;
 mod linux_commands;
+mod openssl_signer;
 
 use anyhow::Result;
 use clap::Parser;

--- a/tools/src/openssl_signer.rs
+++ b/tools/src/openssl_signer.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::linux_commands::{execute, execute_and_parse_stdout};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use std::process::Command;
+use sxg_rs::signature::{Format as SignatureFormat, Signer};
+
+#[derive(Debug)]
+pub enum OpensslSigner<'a> {
+    Hmac(&'a [u8]),
+}
+
+#[async_trait(?Send)]
+impl<'a> Signer for OpensslSigner<'a> {
+    async fn sign(&self, message: &[u8], format: SignatureFormat) -> Result<Vec<u8>> {
+        let tmp_file = execute_and_parse_stdout(&mut Command::new("mktemp"))?;
+        let tmp_file = tmp_file.trim();
+        std::fs::write(tmp_file, message)?;
+        match self {
+            OpensslSigner::Hmac(private_key) => {
+                let hexkey = private_key
+                    .iter()
+                    .map(|x| format!("{:02x}", x))
+                    .collect::<Vec<_>>()
+                    .join("");
+                let sig = execute(
+                    Command::new("openssl")
+                        .arg("dgst")
+                        .arg("-sha256")
+                        .arg("-mac")
+                        .arg("HMAC")
+                        .arg("-binary")
+                        .arg("-macopt")
+                        .arg(format!("hexkey:{}", hexkey))
+                        .arg(tmp_file),
+                )?;
+                match format {
+                    SignatureFormat::Raw => Ok(sig),
+                    SignatureFormat::EccAsn1 => {
+                        Err(anyhow!("HMAC signature can't be formatted as EccAsn1."))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Add a signer to create `HMAC` signature using `openssl`.
* Add EAB key ID and mac key as CLI argument to the tool `cargo run -- apply-acme-cert`. 
* Ignore the error that Google's ACME server does not have a change-key URL.