### PR TITLE
Read existing private key

### DIFF
--- a/tools/src/apply_acme_cert.rs
+++ b/tools/src/apply_acme_cert.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use warp::Filter;
 
 use crate::hyper_fetcher::HyperFetcher;
-use crate::linux_commands::{create_certificate_request_pem, create_private_key_pem};
+use crate::linux_commands::{create_certificate_request_pem, read_or_create_private_key_pem};
 use sxg_rs::acme::directory::Directory;
 use sxg_rs::acme::eab::create_external_account_binding;
 
@@ -61,11 +61,11 @@ fn start_warp_server(port: u16, answer: String) -> tokio::sync::oneshot::Sender<
 
 pub async fn main(opts: Opts) -> Result<()> {
     let acme_private_key = {
-        let private_key_pem = create_private_key_pem(&opts.acme_account_private_key_file)?;
+        let private_key_pem = read_or_create_private_key_pem(&opts.acme_account_private_key_file)?;
         sxg_rs::crypto::EcPrivateKey::from_sec1_pem(&private_key_pem)?
     };
     let sxg_cert_request_der = {
-        create_private_key_pem(&opts.sxg_private_key_file)?;
+        read_or_create_private_key_pem(&opts.sxg_private_key_file)?;
         let cert_request_pem = create_certificate_request_pem(
             &opts.domain,
             &opts.sxg_private_key_file,

--- a/tools/src/gen_dev_cert.rs
+++ b/tools/src/gen_dev_cert.rs
@@ -17,8 +17,8 @@ use clap::Parser;
 use std::fs::write;
 
 use crate::linux_commands::{
-    create_certificate, create_certificate_request_pem, create_private_key_pem,
-    get_certificate_sha256, write_new_file,
+    create_certificate, create_certificate_request_pem, get_certificate_sha256,
+    read_or_create_private_key_pem, write_new_file,
 };
 
 #[derive(Parser)]
@@ -34,7 +34,7 @@ pub fn main(opts: Opts) -> Result<()> {
     const CERT_FILE: &str = "cert.pem";
     const ISSUER_FILE: &str = "issuer.pem";
     const CERT_SHA256_FILE: &str = "cert_sha256.txt";
-    create_private_key_pem(PRIVKEY_FILE)?;
+    read_or_create_private_key_pem(PRIVKEY_FILE)?;
     create_certificate_request_pem(&opts.domain, PRIVKEY_FILE, CERT_CSR_FILE)?;
     write(
         EXT_FILE,

--- a/tools/src/linux_commands.rs
+++ b/tools/src/linux_commands.rs
@@ -63,7 +63,10 @@ pub fn read_or_create_private_key_pem(file: impl AsRef<Path>) -> Result<String> 
                 .arg("-genkey"),
         )
         .map_err(|e| e.context("Failed to use openssl to generate private key"))?;
-        println!("Writing private key to file {:?}, please keep it in a safe place.", file.as_ref());
+        println!(
+            "Writing private key to file {:?}, please keep it in a safe place.",
+            file.as_ref()
+        );
         write_new_file(file, &privkey_pem)?;
         Ok(privkey_pem)
     }

--- a/tools/src/linux_commands.rs
+++ b/tools/src/linux_commands.rs
@@ -50,6 +50,7 @@ pub fn write_new_file(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Resu
 /// generates a private key, and writes PEM to the file, and returns it.
 pub fn read_or_create_private_key_pem(file: impl AsRef<Path>) -> Result<String> {
     if file.as_ref().exists() {
+        println!("Reading private key from file {:?}", file.as_ref());
         std::fs::read_to_string(file).map_err(Error::new)
     } else {
         let privkey_pem = execute_and_parse_stdout(
@@ -62,6 +63,7 @@ pub fn read_or_create_private_key_pem(file: impl AsRef<Path>) -> Result<String> 
                 .arg("-genkey"),
         )
         .map_err(|e| e.context("Failed to use openssl to generate private key"))?;
+        println!("Writing private key to file {:?}, please keep it in a safe place.", file.as_ref());
         write_new_file(file, &privkey_pem)?;
         Ok(privkey_pem)
     }

--- a/tools/src/linux_commands.rs
+++ b/tools/src/linux_commands.rs
@@ -46,8 +46,8 @@ pub fn write_new_file(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Resu
     }
 }
 
-/// Tries to read the content of given file; if the file does not exist,
-/// generates a private key, and writes PEM to file, and returns it.
+/// Tries to read the contents of given file; if the file does not exist,
+/// generates a private key, and writes PEM to the file, and returns it.
 pub fn read_or_create_private_key_pem(file: impl AsRef<Path>) -> Result<String> {
     if file.as_ref().exists() {
         std::fs::read_to_string(file).map_err(Error::new)


### PR DESCRIPTION
Improve the experience of running scripts in a non-empty folder.
* If the private key file argument points to an existing file, read its content, instead of always requesting the user to use a new file name.
* When generating Certificate Signing Request (CSR), overwrite the existing file.