### PR TITLE
Use sha1 for OCSP cert id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.1",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,6 +3618,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2 0.10.2",
  "tokio",
  "tokio-test",

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -48,6 +48,7 @@ p256 = { version = "0.10.1", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.80"
 serde_yaml = "0.8.23"
+sha1 = "0.10.1"
 sha2 = "0.10.2"
 tokio = { version = "1.18.1", features = ["macros", "sync", "time"] }
 url = "2.2.2"

--- a/sxg_rs/src/config.rs
+++ b/sxg_rs/src/config.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::crypto::get_der_from_pem;
+use crate::crypto::HashAlgorithm;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -98,7 +99,7 @@ impl Config {
         issuer_der: Vec<u8>,
     ) -> Self {
         Config {
-            cert_sha256: crate::utils::get_sha(&cert_der),
+            cert_sha256: HashAlgorithm::Sha256.digest(&cert_der),
             cert_der,
             issuer_der,
             input,

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::crypto::HashAlgorithm;
 use crate::fetcher::{Fetcher, NULL_FETCHER};
 use crate::headers::Headers;
 use crate::http::{HttpRequest, HttpResponse, Method};
 use crate::http_cache::{HttpCache, NullCache};
-use crate::utils::{get_sha, signed_headers_and_payload};
+use crate::utils::signed_headers_and_payload;
 use anyhow::{anyhow, Error, Result};
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
@@ -147,7 +148,7 @@ impl<'a, F: Fetcher, C: HttpCache> HeaderIntegrityFetcherImpl<'a, F, C> {
         .await?;
         Ok([
             b"sha256-",
-            base64::encode(get_sha(&signed_headers)).as_bytes(),
+            base64::encode(HashAlgorithm::Sha256.digest(&signed_headers)).as_bytes(),
         ]
         .concat())
     }

--- a/sxg_rs/src/mice.rs
+++ b/sxg_rs/src/mice.rs
@@ -14,12 +14,13 @@
 
 // https://tools.ietf.org/html/draft-thomson-http-mice-03
 
+use crate::crypto::HashAlgorithm;
 use ::sha2::{Digest, Sha256};
 use std::collections::VecDeque;
 
 pub fn calculate(input: &[u8], record_size: usize) -> (Vec<u8>, Vec<u8>) {
     if input.is_empty() {
-        return (crate::utils::get_sha(&[0]), vec![]);
+        return (HashAlgorithm::Sha256.digest(&[0]), vec![]);
     }
     let record_size = std::cmp::min(record_size, input.len());
     let records: Vec<_> = if record_size > 0 {

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -45,13 +45,6 @@ macro_rules! console_dbg {
 #[allow(unused_imports)]
 pub(crate) use console_dbg;
 
-pub fn get_sha(bytes: &[u8]) -> Vec<u8> {
-    use ::sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hasher.finalize().to_vec()
-}
-
 #[cfg(feature = "wasm")]
 pub fn to_js_error<E: std::fmt::Debug>(e: E) -> wasm_bindgen::JsValue {
     // TODO: The `JsValue::from_str()` constructs a `string` in JavaScript.

--- a/tools/src/linux_commands.rs
+++ b/tools/src/linux_commands.rs
@@ -132,5 +132,5 @@ pub fn get_certificate_sha256(certificate_file: impl AsRef<Path>) -> Result<Vec<
             .arg(certificate_file.as_ref().as_os_str()),
     )?;
     let public_key_der = sxg_rs::crypto::get_der_from_pem(&public_key_pem, "PUBLIC KEY")?;
-    Ok(sxg_rs::utils::get_sha(&public_key_der))
+    Ok(sxg_rs::crypto::HashAlgorithm::Sha256.digest(&public_key_der))
 }


### PR DESCRIPTION
We have been using SHA256 for all signatures. However, [RFC5019](https://datatracker.ietf.org/doc/html/rfc5019#section-2.1.1) states that 
> Clients MUST use SHA1 as the hashing algorithm for the
> CertID.issuerNameHash and the CertID.issuerKeyHash values.

Content of this PR
* Rename `sxg_rs::utils::get_sha(...)` as `HashAlgorithm::Sha256.digest(...)`.
* In `ocsp/mod.rs`, use `HashAlgorithm::Sha1.digest(...)`.