### PR TITLE
Move certificates out of config

### DIFF
--- a/sxg_rs/src/config.rs
+++ b/sxg_rs/src/config.rs
@@ -43,7 +43,7 @@ impl Config {
         self.reserved_path = to_url_prefix(&self.reserved_path);
         lowercase_all(&mut self.strip_request_headers);
         lowercase_all(&mut self.strip_response_headers);
-        self.validity_url_dirname = to_url_prefix(&&self.validity_url_dirname);
+        self.validity_url_dirname = to_url_prefix(&self.validity_url_dirname);
     }
     /// Creates config from text
     pub fn new(input_yaml: &str) -> Result<Self> {


### PR DESCRIPTION
* Simplify the structure of sxg worker and its config.

  Old structure
  ```rust
  struct SxgWorker {
    config: Config {
      input: ConfigInput {
        forward_request_headers: BTreeSet<String>,
        ... and many other fields
      },
      cert_der: Vec<u8>,
      cert_sha256: Vec<u8>,
      issuer_der: Vec<u8>,
    }
  }
  ```
  New structore
  ```rust
  struct SxgWorker {
    config: Config {
        forward_request_headers: BTreeSet<String>,
      ... and many other fields
    },
    cert_der: Vec<u8>,
    cert_sha256: Vec<u8>,
    issuer_der: Vec<u8>,
  }
  ```
  

