### PR TITLE
Remove debug info in SXG response

### DIFF
--- a/cloudflare_worker/wrangler.example.toml
+++ b/cloudflare_worker/wrangler.example.toml
@@ -36,7 +36,6 @@ forward_request_headers:
   - cf-ipcountry
 html_host: my_domain.com
 reserved_path: ".sxg"
-respond_debug_info: false
 strip_request_headers: []
 strip_response_headers:
   - set-cookie

--- a/fastly_compute/config.example.yaml
+++ b/fastly_compute/config.example.yaml
@@ -20,7 +20,6 @@ forward_request_headers:
 html_host: my_domain.com
 private_key_base64: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXU="
 reserved_path: ".sxg"
-respond_debug_info: true
 strip_request_headers: []
 strip_response_headers: ["set-cookie", "strict-transport-security"]
 validity_url_dirname: ".well-known/sxg-validity"

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -47,7 +47,6 @@ forward_request_headers:
   - user-agent
   - cf-ipcountry
 reserved_path: ".sxg"
-respond_debug_info: false
 strip_request_headers: []
 strip_response_headers:
   - set-cookie

--- a/sxg_rs/src/config.rs
+++ b/sxg_rs/src/config.rs
@@ -30,7 +30,6 @@ pub struct Config {
     // TODO: check if Fastly edge dictionary is ok to store private key.
     pub private_key_base64: Option<String>,
     pub reserved_path: String,
-    pub respond_debug_info: bool,
     pub strip_request_headers: BTreeSet<String>,
     pub strip_response_headers: BTreeSet<String>,
     pub validity_url_dirname: String,

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -342,9 +342,6 @@ impl SxgWorker {
         signature::rust_signer::RustSigner::new(&private_key_der)
             .map_err(|e| e.context("Failed to call RustSigner::new()."))
     }
-    pub fn should_respond_debug_info(&self) -> bool {
-        self.config.respond_debug_info
-    }
     /// Replaces the host name to be the html_host in the config.
     // TODO: implement get_fallback_url_and_cert_origin, so that Cloudflare Worker can use it.
     pub fn get_fallback_url(&self, original_url: &Url) -> Result<Url> {

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -85,10 +85,6 @@ impl WasmWorker {
                 }))
         })
     }
-    #[wasm_bindgen(js_name=shouldRespondDebugInfo)]
-    pub fn should_respond_debug_info(&self) -> Result<bool, JsValue> {
-        Ok(self.0.should_respond_debug_info())
-    }
 
     #[wasm_bindgen(js_name=createRequestHeaders)]
     pub fn create_request_headers(

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -87,7 +87,6 @@ export interface WasmWorker {
     url: string,
     ocsp: string
   ): Promise<PresetContent | undefined>;
-  shouldRespondDebugInfo(): boolean;
   validatePayloadHeaders(fields: HeaderFields): void;
 }
 


### PR DESCRIPTION
* Remove `respond_debug_info` field from worker config. The SXG response headers will no longer contain debug info.
* Use `console.error` to print debug info. The output is available by [wrangler tail](https://developers.cloudflare.com/workers/cli-wrangler/commands/#tail) command.
* Set the worker in Cloudflare to [pass through on exception](https://developers.cloudflare.com/workers/runtime-apis/fetch-event/#passthroughonexception).