### PR TITLE
Put fetcher and signer into a runtime struct

### DIFF
--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -236,20 +236,24 @@ async function generateSxgResponse(
   }
   const {get: headerIntegrityGet, put: headerIntegrityPut} =
     await headerIntegrityCache();
-  const nowInSeconds = Math.floor(Date.now() / 1000);
-  const sxg = await worker.createSignedExchange({
-    fallbackUrl,
-    certOrigin,
-    statusCode: payload.status,
-    payloadHeaders,
-    payloadBody,
-    skipProcessLink: false,
-    nowInSeconds,
-    signer,
-    subresourceFetcher: fetcher,
-    headerIntegrityGet,
-    headerIntegrityPut,
-  });
+  const sxg = await worker.createSignedExchange(
+    {
+      nowInSeconds: Math.floor(Date.now() / 1000),
+      fetcher,
+      sxgRawSigner: signer,
+      sxgAsn1Signer: undefined,
+    },
+    {
+      fallbackUrl,
+      certOrigin,
+      statusCode: payload.status,
+      payloadHeaders,
+      payloadBody,
+      skipProcessLink: false,
+      headerIntegrityGet,
+      headerIntegrityPut,
+    }
+  );
   return responseFromWasm(sxg);
 }
 

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -100,8 +100,8 @@ fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Respon
     let cert_origin = fallback_url.origin().ascii_serialization();
     let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
-        sxg_signer: Some(Box::new(WORKER.create_rust_signer()?)),
-        fetcher: Some(Box::new(FastlyFetcher::new("subresources"))),
+        sxg_signer: Box::new(WORKER.create_rust_signer()?),
+        fetcher: Box::new(FastlyFetcher::new("subresources")),
     };
     let sxg = WORKER.create_signed_exchange(
         runtime,

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -95,26 +95,29 @@ fn fetch_from_html_server(url: &Url, req_headers: Vec<(String, String)>) -> Resu
 }
 
 fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Response> {
-    let signer = WORKER.create_rust_signer()?;
     let payload_headers = get_rsp_header_fields(&payload)?;
     let payload_body = payload.into_body_bytes();
     let cert_origin = fallback_url.origin().ascii_serialization();
-    let subresource_fetcher = FastlyFetcher::new("subresources");
-    let sxg = WORKER.create_signed_exchange(sxg_rs::CreateSignedExchangeParams {
+    let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
-        payload_body: &payload_body,
-        payload_headers,
-        skip_process_link: false,
-        signer,
-        status_code: 200,
-        fallback_url: fallback_url.as_str(),
-        cert_origin: &cert_origin,
-        subresource_fetcher,
-        // The fastly crate provides only read access to dictionaries, so
-        // header integrities cannot be cached. However, I believe the
-        // subresource_fetcher will go through the cache.
-        header_integrity_cache: sxg_rs::http_cache::NullCache {},
-    });
+        sxg_signer: Some(Box::new(WORKER.create_rust_signer()?)),
+        fetcher: Some(Box::new(FastlyFetcher::new("subresources"))),
+    };
+    let sxg = WORKER.create_signed_exchange(
+        runtime,
+        sxg_rs::CreateSignedExchangeParams {
+            payload_body: &payload_body,
+            payload_headers,
+            skip_process_link: false,
+            status_code: 200,
+            fallback_url: fallback_url.as_str(),
+            cert_origin: &cert_origin,
+            // The fastly crate provides only read access to dictionaries, so
+            // header integrities cannot be cached. However, I believe the
+            // subresource_fetcher will go through the cache.
+            header_integrity_cache: sxg_rs::http_cache::NullCache {},
+        },
+    );
     let sxg = block_on(sxg)?;
     sxg_rs_response_to_fastly_response(sxg)
 }

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -116,7 +116,7 @@ export async function spawnSxgServer({
         skipProcessLink: false,
         headerIntegrityGet: urlRecorder.get,
         headerIntegrityPut: urlRecorder.put,
-      },
+      }
     );
     const subresourceUrls = isTopLevel
       ? Array.from(urlRecorder.visitedUrls())

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -100,19 +100,24 @@ export async function spawnSxgServer({
     sxgPayload = worker.processHtml(sxgPayload, {isSxg: true});
     const urlRecorder = subresourceCache.createRecorder();
     // TODO(PR#157): Use `handleRequest` function in `cloudflare_worker/worker/src/index.ts`.
-    const sxg = await worker.createSignedExchange({
-      fallbackUrl: innerUrl,
-      certOrigin,
-      statusCode: sxgPayload.status,
-      payloadHeaders: sxgPayload.headers,
-      payloadBody: new Uint8Array(sxgPayload.body),
-      skipProcessLink: false,
-      nowInSeconds: Date.now() / 1000,
-      signer,
-      subresourceFetcher: fetcher,
-      headerIntegrityGet: urlRecorder.get,
-      headerIntegrityPut: urlRecorder.put,
-    });
+    const sxg = await worker.createSignedExchange(
+      {
+        nowInSeconds: Date.now() / 1000,
+        sxgAsn1Signer: undefined,
+        sxgRawSigner: signer,
+        fetcher,
+      },
+      {
+        fallbackUrl: innerUrl,
+        certOrigin,
+        statusCode: sxgPayload.status,
+        payloadHeaders: sxgPayload.headers,
+        payloadBody: new Uint8Array(sxgPayload.body),
+        skipProcessLink: false,
+        headerIntegrityGet: urlRecorder.get,
+        headerIntegrityPut: urlRecorder.put,
+      },
+    );
     const subresourceUrls = isTopLevel
       ? Array.from(urlRecorder.visitedUrls())
       : [];

--- a/sxg_rs/src/fetcher/mod.rs
+++ b/sxg_rs/src/fetcher/mod.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 pub trait Fetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse>;
     /// Uses `Get` method and returns response body.
-    async fn get<T: ToString>(&self, url: T) -> Result<Vec<u8>> {
+    async fn get(&self, url: &str) -> Result<Vec<u8>> {
         let request = HttpRequest {
             body: vec![],
             headers: vec![],

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -153,7 +153,7 @@ impl SxgWorker {
         let cert_base = Url::parse(cert_origin)
             .map_err(|e| Error::new(e).context("Failed to parse cert origin"))?;
         let mut header_integrity_fetcher = header_integrity::new_fetcher(
-            runtime.fetcher()?,
+            runtime.fetcher.as_ref(),
             header_integrity_cache,
             &self.config.strip_response_headers,
         );
@@ -194,7 +194,7 @@ impl SxgWorker {
             headers: &signed_headers,
             id: "sig",
             request_url: fallback_url,
-            signer: runtime.sxg_signer()?,
+            signer: runtime.sxg_signer.as_ref(),
             validity_url: validity_url.as_str(),
         })
         .await;

--- a/sxg_rs/src/runtime/js_runtime.rs
+++ b/sxg_rs/src/runtime/js_runtime.rs
@@ -1,0 +1,57 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Runtime;
+use crate::fetcher::{js_fetcher::JsFetcher, Fetcher};
+use crate::signature::{js_signer::JsSigner, Signer};
+use anyhow::{Error, Result};
+use js_sys::Function as JsFunction;
+use std::time::{Duration, SystemTime};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    pub type JsRuntimeInitParams;
+    #[wasm_bindgen(method, getter, js_name = "nowInSeconds")]
+    fn now_in_seconds(this: &JsRuntimeInitParams) -> u32;
+    #[wasm_bindgen(method, getter, js_name = "fetcher")]
+    fn fetcher(this: &JsRuntimeInitParams) -> Option<JsFunction>;
+    #[wasm_bindgen(method, getter, js_name = "sxgAsn1Signer")]
+    fn sxg_asn1_signer(this: &JsRuntimeInitParams) -> Option<JsFunction>;
+    #[wasm_bindgen(method, getter, js_name = "sxgRawSigner")]
+    fn sxg_raw_signer(this: &JsRuntimeInitParams) -> Option<JsFunction>;
+
+}
+
+impl std::convert::TryFrom<JsRuntimeInitParams> for Runtime {
+    type Error = Error;
+    fn try_from(input: JsRuntimeInitParams) -> Result<Self, Self::Error> {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(input.now_in_seconds() as u64);
+        let fetcher = input
+            .fetcher()
+            .map(|f| Box::new(JsFetcher::new(f)) as Box<dyn Fetcher>);
+        let sxg_asn1_signer = input
+            .sxg_asn1_signer()
+            .map(|f| Box::new(JsSigner::from_asn1_signer(f)) as Box<dyn Signer>);
+        let sxg_raw_signer = input
+            .sxg_raw_signer()
+            .map(|f| Box::new(JsSigner::from_raw_signer(f)) as Box<dyn Signer>);
+        let sxg_signer = sxg_asn1_signer.or(sxg_raw_signer);
+        Ok(Runtime {
+            now,
+            fetcher,
+            sxg_signer,
+        })
+    }
+}

--- a/sxg_rs/src/runtime/js_runtime.rs
+++ b/sxg_rs/src/runtime/js_runtime.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use super::Runtime;
-use crate::fetcher::{js_fetcher::JsFetcher, Fetcher};
-use crate::signature::{js_signer::JsSigner, Signer};
+use crate::fetcher::{js_fetcher::JsFetcher, Fetcher, NullFetcher};
+use crate::signature::{js_signer::JsSigner, Signer, mock_signer::MockSigner};
 use anyhow::{Error, Result};
 use js_sys::Function as JsFunction;
 use std::time::{Duration, SystemTime};
@@ -50,8 +50,8 @@ impl std::convert::TryFrom<JsRuntimeInitParams> for Runtime {
         let sxg_signer = sxg_asn1_signer.or(sxg_raw_signer);
         Ok(Runtime {
             now,
-            fetcher,
-            sxg_signer,
+            fetcher: fetcher.unwrap_or_else(|| Box::new(NullFetcher)),
+            sxg_signer: sxg_signer.unwrap_or_else(|| Box::new(MockSigner)),
         })
     }
 }

--- a/sxg_rs/src/runtime/js_runtime.rs
+++ b/sxg_rs/src/runtime/js_runtime.rs
@@ -14,7 +14,7 @@
 
 use super::Runtime;
 use crate::fetcher::{js_fetcher::JsFetcher, Fetcher, NullFetcher};
-use crate::signature::{js_signer::JsSigner, Signer, mock_signer::MockSigner};
+use crate::signature::{js_signer::JsSigner, mock_signer::MockSigner, Signer};
 use anyhow::{Error, Result};
 use js_sys::Function as JsFunction;
 use std::time::{Duration, SystemTime};

--- a/sxg_rs/src/runtime/mod.rs
+++ b/sxg_rs/src/runtime/mod.rs
@@ -17,26 +17,10 @@ pub mod js_runtime;
 
 use crate::fetcher::Fetcher;
 use crate::signature::Signer;
-use anyhow::{anyhow, Result};
 use std::time::SystemTime;
 
 pub struct Runtime {
     pub now: SystemTime,
-    pub fetcher: Option<Box<dyn Fetcher>>,
-    pub sxg_signer: Option<Box<dyn Signer>>,
-}
-
-impl Runtime {
-    pub fn fetcher(&self) -> Result<&dyn Fetcher> {
-        self.fetcher
-            .as_ref()
-            .ok_or_else(|| anyhow!("Runtime does not contain fetcher"))
-            .map(|x| x.as_ref())
-    }
-    pub fn sxg_signer(&self) -> Result<&dyn Signer> {
-        self.sxg_signer
-            .as_ref()
-            .ok_or_else(|| anyhow!("Runtime does not contain SXG signer"))
-            .map(|x| x.as_ref())
-    }
+    pub fetcher: Box<dyn Fetcher>,
+    pub sxg_signer: Box<dyn Signer>,
 }

--- a/sxg_rs/src/runtime/mod.rs
+++ b/sxg_rs/src/runtime/mod.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "wasm")]
+pub mod js_runtime;
+
+use crate::fetcher::Fetcher;
+use crate::signature::Signer;
+use anyhow::{anyhow, Result};
+use std::time::SystemTime;
+
+pub struct Runtime {
+    pub now: SystemTime,
+    pub fetcher: Option<Box<dyn Fetcher>>,
+    pub sxg_signer: Option<Box<dyn Signer>>,
+}
+
+impl Runtime {
+    pub fn fetcher(&self) -> Result<&dyn Fetcher> {
+        self.fetcher
+            .as_ref()
+            .ok_or_else(|| anyhow!("Runtime does not contain fetcher"))
+            .map(|x| x.as_ref())
+    }
+    pub fn sxg_signer(&self) -> Result<&dyn Signer> {
+        self.sxg_signer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Runtime does not contain SXG signer"))
+            .map(|x| x.as_ref())
+    }
+}

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -37,7 +37,7 @@ pub trait Signer {
     async fn sign(&self, message: &[u8], format: Format) -> Result<Vec<u8>>;
 }
 
-pub struct SignatureParams<'a, S: Signer> {
+pub struct SignatureParams<'a> {
     pub cert_url: &'a str,
     pub cert_sha256: &'a [u8],
     pub date: std::time::SystemTime,
@@ -45,7 +45,7 @@ pub struct SignatureParams<'a, S: Signer> {
     pub headers: &'a [u8],
     pub id: &'a str,
     pub request_url: &'a str,
-    pub signer: S,
+    pub signer: &'a dyn Signer,
     pub validity_url: &'a str,
 }
 
@@ -69,7 +69,7 @@ fn seven_days_from(date: &std::time::SystemTime) -> Result<std::time::SystemTime
 }
 
 impl<'a> Signature<'a> {
-    pub async fn new<S: Signer>(params: SignatureParams<'a, S>) -> Result<Signature<'a>> {
+    pub async fn new(params: SignatureParams<'a>) -> Result<Signature<'a>> {
         let SignatureParams {
             cert_url,
             cert_sha256,

--- a/tools/src/gen_sxg.rs
+++ b/tools/src/gen_sxg.rs
@@ -42,8 +42,8 @@ pub async fn main(opts: Opts) -> Result<()> {
         .unwrap();
     let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
-        sxg_signer: Some(Box::new(worker.create_rust_signer().unwrap())),
-        fetcher: Some(Box::new(NULL_FETCHER)),
+        sxg_signer: Box::new(worker.create_rust_signer().unwrap()),
+        fetcher: Box::new(NULL_FETCHER),
     };
     let sxg = worker.create_signed_exchange(
         runtime,

--- a/tools/src/gen_sxg.rs
+++ b/tools/src/gen_sxg.rs
@@ -40,18 +40,23 @@ pub async fn main(opts: Opts) -> Result<()> {
     let payload_headers = worker
         .transform_payload_headers(vec![("content-type".into(), "text/html".into())])
         .unwrap();
-    let sxg = worker.create_signed_exchange(CreateSignedExchangeParams {
-        fallback_url: "https://test.example/",
-        cert_origin: "https://test.example",
+    let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
-        payload_body: b"This is a test.",
-        payload_headers,
-        skip_process_link: false,
-        signer: worker.create_rust_signer().unwrap(),
-        status_code: 200,
-        subresource_fetcher: NULL_FETCHER,
-        header_integrity_cache: NullCache {},
-    });
+        sxg_signer: Some(Box::new(worker.create_rust_signer().unwrap())),
+        fetcher: Some(Box::new(NULL_FETCHER)),
+    };
+    let sxg = worker.create_signed_exchange(
+        runtime,
+        CreateSignedExchangeParams {
+            fallback_url: "https://test.example/",
+            cert_origin: "https://test.example",
+            payload_body: b"This is a test.",
+            payload_headers,
+            skip_process_link: false,
+            status_code: 200,
+            header_integrity_cache: NullCache {},
+        },
+    );
     let sxg = executor::block_on(sxg);
     fs::write(opts.out_sxg, &sxg.unwrap().body)?;
     Ok(())

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -57,7 +57,7 @@ export type JsRuntimeInitParams = {
   fetcher: ((request: WasmRequest) => Promise<WasmResponse>) | undefined;
   sxgAsn1Signer: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
   sxgRawSigner: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
-}
+};
 
 export type CreateSignedExchangedOptions = {
   fallbackUrl: string;
@@ -82,7 +82,10 @@ export interface WasmWorker {
     fields: HeaderFields
   ): HeaderFields;
   processHtml(input: WasmResponse, option: ProcessHtmlOption): WasmResponse;
-  createSignedExchange(runtime: JsRuntimeInitParams, options: CreateSignedExchangedOptions): WasmResponse;
+  createSignedExchange(
+    runtime: JsRuntimeInitParams,
+    options: CreateSignedExchangedOptions
+  ): WasmResponse;
   fetchOcspFromCa(
     fetcher: (request: WasmRequest) => Promise<WasmResponse>
   ): Uint8Array;

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -52,6 +52,13 @@ export type PresetContent =
       fallback: WasmResponse;
     };
 
+export type JsRuntimeInitParams = {
+  nowInSeconds: number;
+  fetcher: ((request: WasmRequest) => Promise<WasmResponse>) | undefined;
+  sxgAsn1Signer: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
+  sxgRawSigner: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
+}
+
 export type CreateSignedExchangedOptions = {
   fallbackUrl: string;
   certOrigin: string;
@@ -59,9 +66,6 @@ export type CreateSignedExchangedOptions = {
   payloadHeaders: HeaderFields;
   payloadBody: Uint8Array;
   skipProcessLink: boolean;
-  nowInSeconds: number;
-  signer: (input: Uint8Array) => Promise<Uint8Array>;
-  subresourceFetcher: (request: WasmRequest) => Promise<WasmResponse>;
   headerIntegrityGet: (url: string) => Promise<WasmResponse>;
   headerIntegrityPut: (url: string, response: WasmResponse) => Promise<void>;
 };
@@ -78,7 +82,7 @@ export interface WasmWorker {
     fields: HeaderFields
   ): HeaderFields;
   processHtml(input: WasmResponse, option: ProcessHtmlOption): WasmResponse;
-  createSignedExchange(options: CreateSignedExchangedOptions): WasmResponse;
+  createSignedExchange(runtime: JsRuntimeInitParams, options: CreateSignedExchangedOptions): WasmResponse;
   fetchOcspFromCa(
     fetcher: (request: WasmRequest) => Promise<WasmResponse>
   ): Uint8Array;


### PR DESCRIPTION
* Create a `Runtime` struct, containing `fetcher`, `sxg_signer` and `now`.
* Remove runtime fields from `CreateSignedExchangeParams`.
* No longer use generic declarations `<F: Fetcher>` and `<S: Signer>`, which are like C++ template types (types determined at compile time, and compiler creates the binary code for every `F` and `S`). The new code now use `&dyn Fetcher` and `&dyn Signer`, which are like C++ abstract class.