### PR TITLE
Create Storage trait for OCSP

### DIFF
--- a/cloudflare_worker/worker/src/storage.ts
+++ b/cloudflare_worker/worker/src/storage.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export async function storageRead(k: string): Promise<string | null> {
+  return await OCSP.get(k);
+}
+
+export async function storageWrite(k: string, v: string): Promise<void> {
+  await OCSP.put(k, v);
+}

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0.80"
 serde_yaml = "0.8.23"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
-tokio = { version = "1.18.1", features = ["macros", "sync", "time"] }
+tokio = { version = "1.18.1", features = ["macros", "parking_lot", "sync", "time"] }
 url = "2.2.2"
 wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.30"

--- a/sxg_rs/src/runtime/mod.rs
+++ b/sxg_rs/src/runtime/mod.rs
@@ -17,10 +17,12 @@ pub mod js_runtime;
 
 use crate::fetcher::Fetcher;
 use crate::signature::Signer;
+use crate::storage::Storage;
 use std::time::SystemTime;
 
 pub struct Runtime {
     pub now: SystemTime,
     pub fetcher: Box<dyn Fetcher>,
+    pub storage: Box<dyn Storage>,
     pub sxg_signer: Box<dyn Signer>,
 }

--- a/sxg_rs/src/storage/js_storage.rs
+++ b/sxg_rs/src/storage/js_storage.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Storage;
+use crate::utils::await_js_promise;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use js_sys::Function as JsFunction;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct JsStorage {
+    read: Option<JsFunction>,
+    write: Option<JsFunction>,
+}
+
+#[wasm_bindgen]
+impl JsStorage {
+    /// Creates a storage by two JavaScript async functions.
+    /// `read` must be of type `(key: string) => Promise<string | nulL>`;
+    /// `write` must be of type `(key: string, value: string) => Promise<void>`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(read: Option<JsFunction>, write: Option<JsFunction>) -> Self {
+        JsStorage { read, write }
+    }
+}
+
+#[async_trait(?Send)]
+impl Storage for JsStorage {
+    async fn read(&self, k: &str) -> Result<Option<String>> {
+        if let Some(read) = &self.read {
+            let k = JsValue::from_str(k);
+            let v = await_js_promise(read.call1(&JsValue::NULL, &k)).await?;
+            if v.is_null() {
+                return Ok(None);
+            }
+            let v = v
+                .as_string()
+                .ok_or_else(|| anyhow!("Expecting JavaScript function to return a string"))?;
+            Ok(Some(v))
+        } else {
+            Ok(None)
+        }
+    }
+    async fn write(&self, k: &str, v: &str) -> Result<()> {
+        if let Some(write) = &self.write {
+            let k = JsValue::from_str(k);
+            let v = serde_json::to_string(v)?;
+            let v = JsValue::from_str(&v);
+            await_js_promise(write.call2(&JsValue::NULL, &k, &v)).await?;
+        }
+        Ok(())
+    }
+}

--- a/sxg_rs/src/storage/mod.rs
+++ b/sxg_rs/src/storage/mod.rs
@@ -1,0 +1,55 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "wasm")]
+pub mod js_storage;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+#[async_trait(?Send)]
+pub trait Storage {
+    async fn read(&self, k: &str) -> Result<Option<String>>;
+    async fn write(&self, k: &str, v: &str) -> Result<()>;
+}
+
+pub struct InMemoryStorage(Arc<RwLock<HashMap<String, String>>>);
+
+impl InMemoryStorage {
+    pub fn new() -> Self {
+        InMemoryStorage(Arc::new(RwLock::new(HashMap::new())))
+    }
+}
+
+#[async_trait(?Send)]
+impl Storage for InMemoryStorage {
+    async fn read(&self, k: &str) -> Result<Option<String>> {
+        let guard = self.0.read().await;
+        Ok(guard.get(k).map(|v| v.to_string()))
+    }
+    async fn write(&self, k: &str, v: &str) -> Result<()> {
+        let mut guard = self.0.write().await;
+        guard.insert(k.to_string(), v.to_string());
+        Ok(())
+    }
+}
+
+impl std::default::Default for InMemoryStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tools/src/gen_sxg.rs
+++ b/tools/src/gen_sxg.rs
@@ -42,11 +42,12 @@ pub async fn main(opts: Opts) -> Result<()> {
         .unwrap();
     let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
+        storage: Box::new(sxg_rs::storage::InMemoryStorage::new()),
         sxg_signer: Box::new(worker.create_rust_signer().unwrap()),
         fetcher: Box::new(NULL_FETCHER),
     };
     let sxg = worker.create_signed_exchange(
-        runtime,
+        &runtime,
         CreateSignedExchangeParams {
             fallback_url: "https://test.example/",
             cert_origin: "https://test.example",

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -55,6 +55,8 @@ export type PresetContent =
 export type JsRuntimeInitParams = {
   nowInSeconds: number;
   fetcher: ((request: WasmRequest) => Promise<WasmResponse>) | undefined;
+  storageRead: ((k: string) => Promise<string | null>) | undefined;
+  storageWrite: ((k: string, v: string) => Promise<void>) | undefined;
   sxgAsn1Signer: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
   sxgRawSigner: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
 };
@@ -86,13 +88,11 @@ export interface WasmWorker {
     runtime: JsRuntimeInitParams,
     options: CreateSignedExchangedOptions
   ): WasmResponse;
-  fetchOcspFromCa(
-    fetcher: (request: WasmRequest) => Promise<WasmResponse>
-  ): Uint8Array;
+  updateOcspInStorage(runtime: JsRuntimeInitParams): Uint8Array;
   getLastErrorMessage(): string;
   servePresetContent(
-    url: string,
-    ocsp: string
+    runtime: JsRuntimeInitParams,
+    url: string
   ): Promise<PresetContent | undefined>;
   validatePayloadHeaders(fields: HeaderFields): void;
 }


### PR DESCRIPTION
* Create `Storage` trait for abstract reading and writing.
* Implement `Storage` trait by Cloudlfare [KV](https://developers.cloudflare.com/workers/runtime-apis/kv).
* Add storage to be a field of runtime.
* Move OCSP storage and expiration checking code from TypeScript into Rust.
  * Previously, TypeScript called `worker.fetchOcspFromCa()` and then passed `ocsp_der` to `worker.servePresetContent()`.
  * After this PR, TypeScript only provide a runtime to `worker.servePresetContent`, and Rust decides whether or not to refetch from CA.