### PR TITLE
Remove runtime value inside ACME client

### DIFF
--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -101,6 +101,7 @@ function createRuntime() {
     storageWrite,
     sxgRawSigner: signer,
     sxgAsn1Signer: undefined,
+    acmeRawSigner: undefined, // ACME does not run in Worker yet
   };
 }
 

--- a/playground/src/server/index.ts
+++ b/playground/src/server/index.ts
@@ -93,6 +93,7 @@ export async function spawnSxgServer({
       storageWrite: storage.write,
       sxgAsn1Signer: undefined,
       sxgRawSigner: signer,
+      acmeRawSigner: undefined, // Playground uses self-signed certificate, and does not use ACME.
       fetcher,
     };
   }

--- a/sxg_rs/src/acme/directory.rs
+++ b/sxg_rs/src/acme/directory.rs
@@ -39,7 +39,7 @@ pub struct Directory {
 
 impl Directory {
     /// Constructs an ACME directory by fetching the given ACME directory URL.
-    pub async fn new<F: Fetcher>(url: &str, fetcher: &F) -> Result<Self> {
+    pub async fn new(url: &str, fetcher: &dyn Fetcher) -> Result<Self> {
         let bytes = fetcher
             .get(url)
             .await

--- a/sxg_rs/src/acme/eab.rs
+++ b/sxg_rs/src/acme/eab.rs
@@ -40,5 +40,10 @@ pub async fn create_external_account_binding(
     hmac_signer: &dyn Signer,
 ) -> Result<JsonWebSignature> {
     let protected_header = EabProtectedHeader { alg, kid, url };
-    JsonWebSignature::new(protected_header, /*payload=*/ Some(public_key), hmac_signer).await
+    JsonWebSignature::new(
+        protected_header,
+        /*payload=*/ Some(public_key),
+        hmac_signer,
+    )
+    .await
 }

--- a/sxg_rs/src/acme/eab.rs
+++ b/sxg_rs/src/acme/eab.rs
@@ -32,12 +32,12 @@ struct EabProtectedHeader<'a> {
     url: &'a str,
 }
 
-pub async fn create_external_account_binding<S: Signer>(
+pub async fn create_external_account_binding(
     alg: Algorithm,
     kid: &str,
     url: &str,
     public_key: &EcPublicKey,
-    signer: &S,
+    signer: &dyn Signer,
 ) -> Result<JsonWebSignature> {
     let protected_header = EabProtectedHeader { alg, kid, url };
     JsonWebSignature::new(protected_header, /*payload=*/ Some(public_key), signer).await

--- a/sxg_rs/src/acme/eab.rs
+++ b/sxg_rs/src/acme/eab.rs
@@ -37,8 +37,8 @@ pub async fn create_external_account_binding(
     kid: &str,
     url: &str,
     public_key: &EcPublicKey,
-    signer: &dyn Signer,
+    hmac_signer: &dyn Signer,
 ) -> Result<JsonWebSignature> {
     let protected_header = EabProtectedHeader { alg, kid, url };
-    JsonWebSignature::new(protected_header, /*payload=*/ Some(public_key), signer).await
+    JsonWebSignature::new(protected_header, /*payload=*/ Some(public_key), hmac_signer).await
 }

--- a/sxg_rs/src/runtime/js_runtime.rs
+++ b/sxg_rs/src/runtime/js_runtime.rs
@@ -36,6 +36,9 @@ extern "C" {
     fn sxg_asn1_signer(this: &JsRuntimeInitParams) -> Option<JsFunction>;
     #[wasm_bindgen(method, getter, js_name = "sxgRawSigner")]
     fn sxg_raw_signer(this: &JsRuntimeInitParams) -> Option<JsFunction>;
+    #[wasm_bindgen(method, getter, js_name = "AcmeRawSigner")]
+    fn acme_raw_signer(this: &JsRuntimeInitParams) -> Option<JsFunction>;
+
 }
 
 impl std::convert::TryFrom<JsRuntimeInitParams> for Runtime {
@@ -54,11 +57,15 @@ impl std::convert::TryFrom<JsRuntimeInitParams> for Runtime {
             .sxg_raw_signer()
             .map(|f| Box::new(JsSigner::from_raw_signer(f)) as Box<dyn Signer>);
         let sxg_signer = sxg_asn1_signer.or(sxg_raw_signer);
+        let acme_signer = input
+            .acme_raw_signer()
+            .map(|f| Box::new(JsSigner::from_raw_signer(f)) as Box<dyn Signer>);
         Ok(Runtime {
             now,
             fetcher: fetcher.unwrap_or_else(|| Box::new(NullFetcher)),
             storage,
             sxg_signer: sxg_signer.unwrap_or_else(|| Box::new(MockSigner)),
+            acme_signer: acme_signer.unwrap_or_else(|| Box::new(MockSigner)),
         })
     }
 }

--- a/sxg_rs/src/runtime/mod.rs
+++ b/sxg_rs/src/runtime/mod.rs
@@ -25,6 +25,7 @@ pub struct Runtime {
     pub fetcher: Box<dyn Fetcher>,
     pub storage: Box<dyn Storage>,
     pub sxg_signer: Box<dyn Signer>,
+    pub acme_signer: Box<dyn Signer>,
 }
 
 impl Default for Runtime {
@@ -34,6 +35,7 @@ impl Default for Runtime {
             fetcher: Box::new(NullFetcher),
             storage: Box::new(InMemoryStorage::default()),
             sxg_signer: Box::new(MockSigner),
+            acme_signer: Box::new(MockSigner),
         }
     }
 }

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -59,6 +59,7 @@ export type JsRuntimeInitParams = {
   storageWrite: ((k: string, v: string) => Promise<void>) | undefined;
   sxgAsn1Signer: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
   sxgRawSigner: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
+  acmeRawSigner: ((input: Uint8Array) => Promise<Uint8Array>) | undefined;
 };
 
 export type CreateSignedExchangedOptions = {


### PR DESCRIPTION
* No longer use `fetcher` and `signer` as member variables of `acme::Client`, making it possible to serialize `acme::Client` as JSON.
* Add `fetcher` and `signer` as parameters of `Client` method functions.
* Declare `acme_signer` as a member variable of `Runtime`.