### PR TITLE
Split ACME account creating and order placing

### DIFF
--- a/sxg_rs/src/acme/client.rs
+++ b/sxg_rs/src/acme/client.rs
@@ -21,9 +21,10 @@ use crate::http::{HttpRequest, HttpResponse, Method};
 use crate::signature::Signer;
 use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 pub struct Client {
-    pub directory: Directory,
+    pub directory: Arc<Directory>,
     pub auth_method: AuthMethod,
     nonce: Option<String>,
 }
@@ -34,7 +35,7 @@ pub enum AuthMethod {
 }
 
 impl Client {
-    pub async fn new(directory: Directory, auth_method: AuthMethod) -> Result<Self> {
+    pub async fn new(directory: Arc<Directory>, auth_method: AuthMethod) -> Result<Self> {
         Ok(Client {
             directory,
             auth_method,


### PR DESCRIPTION
* Split account creating and order placing as two steps.
  ```diff
  - create_request_and_get_challenge_answer(...)
  + create_account(...)
  + place_new_order(...)
    continue_challenge_validation_and_get_certificate(...)
  ```
* The `Client` struct is recreated on each step, hence there will be two more `new-nonce` request sent to ACME server, as demonstrated in the unit test.

In the future, we will keep `create_account` step to run on local machine, and move `place_new_order` step to run in online Worker.