### PR TITLE
Make ACME account object serializable

### DIFF
--- a/sxg_rs/src/acme/client.rs
+++ b/sxg_rs/src/acme/client.rs
@@ -21,10 +21,9 @@ use crate::http::{HttpRequest, HttpResponse, Method};
 use crate::signature::Signer;
 use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
-pub struct Client {
-    pub directory: Arc<Directory>,
+pub struct Client<'a> {
+    pub directory: &'a Directory,
     pub auth_method: AuthMethod,
     nonce: Option<String>,
 }
@@ -34,8 +33,8 @@ pub enum AuthMethod {
     KeyId(String),
 }
 
-impl Client {
-    pub async fn new(directory: Arc<Directory>, auth_method: AuthMethod) -> Result<Self> {
+impl<'a> Client<'a> {
+    pub async fn new(directory: &'a Directory, auth_method: AuthMethod) -> Result<Client<'a>> {
         Ok(Client {
             directory,
             auth_method,

--- a/sxg_rs/src/acme/client.rs
+++ b/sxg_rs/src/acme/client.rs
@@ -34,12 +34,12 @@ pub enum AuthMethod {
 }
 
 impl<'a> Client<'a> {
-    pub async fn new(directory: &'a Directory, auth_method: AuthMethod) -> Result<Client<'a>> {
-        Ok(Client {
+    pub fn new(directory: &'a Directory, auth_method: AuthMethod) -> Self {
+        Client {
             directory,
             auth_method,
             nonce: None,
-        })
+        }
     }
     /// Fetches a server resource at given URL using
     /// [POST-as-GET](https://datatracker.ietf.org/doc/html/rfc8555#section-6.3)

--- a/sxg_rs/src/acme/directory.rs
+++ b/sxg_rs/src/acme/directory.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 /// The URLs for each operation on a ACME server.
 // https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.1
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Directory {
     pub new_nonce: String,
@@ -51,7 +51,7 @@ impl Directory {
 
 /// The meta data in ACME directory object
 // https://datatracker.ietf.org/doc/html/rfc8555#section-9.7.6
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaData {
     pub terms_of_service: String,

--- a/sxg_rs/src/acme/mod.rs
+++ b/sxg_rs/src/acme/mod.rs
@@ -83,8 +83,7 @@ pub async fn create_account(
     let mut client = Client::new(
         &directory,
         client::AuthMethod::JsonWebKey(params.public_key),
-    )
-    .await?;
+    );
     if params.agreed_terms_of_service != client.directory.meta.terms_of_service {
         return Err(anyhow!(
             "Please read and include the terms of service {}",
@@ -135,8 +134,7 @@ pub async fn place_new_order(
     let mut client = Client::new(
         &account.server_directory,
         AuthMethod::KeyId(account.account_url.clone()),
-    )
-    .await?;
+    );
     let (order, order_url) = {
         let request_payload = NewOrderRequestPayload {
             identifiers: vec![Identifier {
@@ -196,8 +194,7 @@ pub async fn continue_challenge_validation_and_get_certificate(
     let mut client = Client::new(
         &account.server_directory,
         AuthMethod::KeyId(account.account_url.clone()),
-    )
-    .await?;
+    );
     // https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.1
     // The client indicates to the server that it is ready for the challenge
     // validation by sending an empty JSON body ("{}") carried in a POST


### PR DESCRIPTION
* Add `#[derive(Serialize, Deserialize)]` to `acme::Account`.
* No longer use `Arc` in `Account`, because `Arc` is not serializable.
* Simplify the declaration of `Client::new` constructor.