### PR TITLE
Only store directory URL in ACME account

### DIFF
--- a/sxg_rs/src/acme/client.rs
+++ b/sxg_rs/src/acme/client.rs
@@ -34,11 +34,11 @@ pub enum AuthMethod {
 }
 
 impl<'a> Client<'a> {
-    pub fn new(directory: &'a Directory, auth_method: AuthMethod) -> Self {
+    pub fn new(directory: &'a Directory, auth_method: AuthMethod, nonce: Option<String>) -> Self {
         Client {
             directory,
             auth_method,
-            nonce: None,
+            nonce,
         }
     }
     /// Fetches a server resource at given URL using

--- a/tools/src/commands/apply_acme_cert.rs
+++ b/tools/src/commands/apply_acme_cert.rs
@@ -82,8 +82,9 @@ pub async fn main(opts: Opts) -> Result<()> {
         (Some(eab_key_id), Some(eab_mac_key)) => {
             let eab_mac_key = base64::decode_config(eab_mac_key, base64::URL_SAFE_NO_PAD)?;
             let eab_signer = crate::runtime::openssl_signer::OpensslSigner::Hmac(&eab_mac_key);
-            let new_account_url = Directory::new(&opts.acme_server, runtime.fetcher.as_ref())
+            let new_account_url = Directory::from_url(&opts.acme_server, runtime.fetcher.as_ref())
                 .await?
+                .0
                 .new_account;
             let eab = create_external_account_binding(
                 sxg_rs::acme::jws::Algorithm::HS256,


### PR DESCRIPTION
* No longer store the entire `Directory` struct in ACME account, and store only directory URL instead.
* Parse `nonce` from header when fetching ACME directory.
* Refetch from directory URL each time the `Client` is recreated.
* Note: the overall number of requests sent to the server is not changed. The previous `new-nonce` requests are changed to directory requests.