### PR TITLE
No longer declare tools::main as an async function

### DIFF
--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -14,7 +14,7 @@
 
 use crate::header_integrity::HeaderIntegrityFetcher;
 use crate::headers::Headers;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Result};
 use url::Url;
 
 #[cfg(all(target_family = "wasm", feature = "wasm"))]
@@ -63,7 +63,7 @@ pub async fn await_js_promise(
     let value =
         result.map_err(|e| anyhow!("{:?}", e).context("JavaScript function throws an error"))?;
     let promise = js_sys::Promise::try_from(value)
-        .map_err(|e| Error::new(e).context("Expecting a JavaScript Promise"))?;
+        .map_err(|e| anyhow::Error::new(e).context("Expecting a JavaScript Promise"))?;
     wasm_bindgen_futures::JsFuture::from(promise)
         .await
         .map_err(|e| anyhow!("{:?}", e).context("JavaScript throws an error asynchronously"))

--- a/tools/src/commands/mod.rs
+++ b/tools/src/commands/mod.rs
@@ -19,6 +19,7 @@ mod gen_sxg;
 
 use anyhow::Result;
 use clap::Parser;
+use futures::executor::block_on;
 
 #[derive(Parser)]
 enum SubCommand {
@@ -34,11 +35,11 @@ struct Opts {
     sub_command: SubCommand,
 }
 
-pub async fn main() -> Result<()> {
+pub fn main() -> Result<()> {
     match Opts::parse().sub_command {
-        SubCommand::ApplyAcmeCert(opts) => apply_acme_cert::main(opts).await,
+        SubCommand::ApplyAcmeCert(opts) => block_on(apply_acme_cert::main(opts)),
         SubCommand::GenConfig(opts) => gen_config::main(opts),
-        SubCommand::GenSxg(opts) => gen_sxg::main(opts).await,
+        SubCommand::GenSxg(opts) => block_on(gen_sxg::main(opts)),
         SubCommand::GenDevCert(opts) => gen_dev_cert::main(opts),
     }
 }

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -18,7 +18,6 @@ mod runtime;
 
 use anyhow::Result;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    commands::main().await
+fn main() -> Result<()> {
+    commands::main()
 }


### PR DESCRIPTION
`gen_config/mod.rs` uses `wrangler` library, and `wrangler` asserts that it is running in a synchronous context. Hence we have to change all direct and indirect callers of `gen_config/mod.rs` to be synchronous.

