### PR TITLE
Remove block_on in async context

### DIFF
--- a/tools/src/commands/gen_sxg.rs
+++ b/tools/src/commands/gen_sxg.rs
@@ -14,7 +14,6 @@
 
 use anyhow::Result;
 use clap::Parser;
-use futures::executor;
 use std::fs;
 use sxg_rs::{fetcher::NULL_FETCHER, http_cache::NullCache, CreateSignedExchangeParams, SxgWorker};
 
@@ -58,7 +57,7 @@ pub async fn main(opts: Opts) -> Result<()> {
             header_integrity_cache: NullCache {},
         },
     );
-    let sxg = executor::block_on(sxg);
+    let sxg = sxg.await;
     fs::write(opts.out_sxg, &sxg.unwrap().body)?;
     Ok(())
 }


### PR DESCRIPTION
Fix the bug that executes `block_on` in `async fn`. This bug has been causing gen-sxg integration tests to fail.