### PR TITLE
No longer use async_std::test and futures executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,122 +116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "futures-lite",
- "num_cpus",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
-dependencies = [
- "concurrent-queue",
- "futures-lite",
- "libc",
- "log",
- "once_cell",
- "parking",
- "polling",
- "slab",
- "socket2",
- "waker-fn",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-std"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "num_cpus",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,12 +137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
-
-[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,12 +146,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -411,20 +283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "bstr"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,12 +364,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "cache-padded"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -676,15 +528,6 @@ checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
 dependencies = [
  "bytes 1.0.1",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -921,16 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1240,12 +1073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,7 +1163,6 @@ dependencies = [
  "async-trait",
  "base64",
  "fastly",
- "futures",
  "http",
  "log",
  "log-fastly",
@@ -1346,15 +1172,6 @@ dependencies = [
  "serde_yaml",
  "sxg_rs",
  "tokio",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -1525,21 +1342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,19 +1451,6 @@ dependencies = [
  "fnv",
  "log",
  "regex",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1952,15 +1741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,15 +1802,6 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -2107,7 +1878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "value-bag",
 ]
 
 [[package]]
@@ -2573,12 +2343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,19 +2506,6 @@ dependencies = [
  "line-wrap",
  "serde",
  "xml-rs",
-]
-
-[[package]]
-name = "polling"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "log",
- "wepoll-ffi",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3583,7 +3334,6 @@ name = "sxg_rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "base64",
  "chrono",
@@ -3979,7 +3729,6 @@ dependencies = [
  "cloudflare",
  "ctrlc",
  "der-parser",
- "futures",
  "http",
  "hyper",
  "hyper-tls",
@@ -4190,16 +3939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.0.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,12 +3955,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -4387,15 +4120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -27,7 +27,6 @@ anyhow = "1.0.57"
 async-trait = "0.1.53"
 base64 = "0.13.0"
 fastly = "^0.8.5"
-futures = { version = "0.3.21", features = ["executor"] }
 http = "0.2.7"
 log = "0.4.17"
 log-fastly = "0.8.5"

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -36,7 +36,7 @@ async-trait = "0.1.53"
 base64 = "0.13.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 der-parser = { version = "7.0.0", features = ["bigint", "serialize"] }
-futures = { version = "0.3.21", features = ["executor"] }
+futures = { version = "0.3.21" }
 getrandom = { version = "0.2.6", features = ["js"] }
 http = "0.2.7"
 js-sys = "0.3.57"
@@ -58,5 +58,4 @@ web-sys = { version = "0.3.57", features = ["console"] }
 x509-parser = "0.13.2"
 
 [dev-dependencies]
-async-std = { version = "1.11.0", features = ["attributes"] }
 tokio-test = "0.4.2"

--- a/sxg_rs/src/acme/jws.rs
+++ b/sxg_rs/src/acme/jws.rs
@@ -126,7 +126,7 @@ impl JsonWebSignature {
 
 #[cfg(test)]
 mod tests {
-    #[async_std::test]
+    #[tokio::test]
     #[cfg(feature = "rust_signer")]
     async fn json_web_signature() {
         use super::*;

--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -209,7 +209,7 @@ pub mod tests {
         FakeFetcher(Box::leak(test_response))
     });
 
-    #[async_std::test]
+    #[tokio::test]
     async fn computes_integrity() {
         let strip_response_headers = BTreeSet::new();
         let fetcher = new_fetcher(
@@ -223,7 +223,7 @@ pub mod tests {
         );
     }
 
-    // RefCell is good enough for our single-threaded, single-task unit tests, but async_std::Mutex
+    // RefCell is good enough for our single-threaded, single-task unit tests, but tokio::Mutex
     // would be necessary for more complex usage.
     struct InMemoryCache<'a>(&'a RefCell<HashMap<String, HttpResponse>>);
 
@@ -244,7 +244,7 @@ pub mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn gets_header_integrity_from_cache() {
         let store = RefCell::new(HashMap::new());
         let cache = InMemoryCache(&store);
@@ -264,7 +264,7 @@ pub mod tests {
 
         assert_eq!(fetcher.fetch(TEST_URL).await.unwrap(), "sha256-blah",);
     }
-    #[async_std::test]
+    #[tokio::test]
     async fn gets_error_from_cache() {
         let store = RefCell::new(HashMap::new());
         let cache = InMemoryCache(&store);
@@ -287,7 +287,7 @@ pub mod tests {
             "something went wrong",
         )
     }
-    #[async_std::test]
+    #[tokio::test]
     async fn puts_into_cache() {
         let store = RefCell::new(HashMap::new());
 
@@ -304,7 +304,7 @@ pub mod tests {
             EXPECTED_HEADER_INTEGRITY.as_bytes(),
         );
     }
-    #[async_std::test]
+    #[tokio::test]
     async fn out_of_order() {
         use crate::utils::tests::{out_of_order, OutOfOrderState};
         use futures::{

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -791,7 +791,7 @@ mod tests {
     }
 
     // === get_signed_headers ===
-    #[async_std::test]
+    #[tokio::test]
     async fn strip_id_headers() {
         let url = Url::parse("https://foo.com").unwrap();
         assert_eq!(
@@ -839,7 +839,7 @@ mod tests {
             ])
         );
     }
-    #[async_std::test]
+    #[tokio::test]
     async fn includes_link_if_valid() {
         let url = Url::parse("https://foo.com").unwrap();
         assert_eq!(
@@ -888,7 +888,7 @@ mod tests {
     }
 
     // === get_signed_headers_bytes ===
-    #[async_std::test]
+    #[tokio::test]
     async fn get_signed_headers_bytes() {
         let url = Url::parse("https://foo.com").unwrap();
         assert_eq!(headers(vec![("content-type", "image/jpeg")]).get_signed_headers_bytes(&url, 200, &[], &mut null_integrity_fetcher(), false).await,

--- a/sxg_rs/src/link.rs
+++ b/sxg_rs/src/link.rs
@@ -191,7 +191,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn sanitizes_preloads() {
         let url = Url::parse("https://foo.com").unwrap();
         assert_eq!(
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[cfg(feature = "srcset")]
-    #[async_std::test]
+    #[tokio::test]
     async fn imagesrcset() {
         let url = Url::parse("https://foo.com").unwrap();
         assert_eq!(
@@ -317,7 +317,7 @@ mod tests {
         );
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn fetch_header_integrity_ok() {
         let mut fetcher = FakeIntegrityFetcher(Ok(
             "sha256-OcpYAC5zFQtAXUURzXkMDDxMbxuEeWVjdRCDcLcBhBY=".into(),
@@ -335,7 +335,7 @@ mod tests {
                    r#"<https://foo.com/>;rel=preload,<https://foo.com/>;rel=allowed-alt-sxg;header-integrity="sha256-OcpYAC5zFQtAXUURzXkMDDxMbxuEeWVjdRCDcLcBhBY=""#);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn fetch_header_integrity_multiple() {
         let mut fetcher = FakeIntegrityFetcher(Ok(
             "sha256-OcpYAC5zFQtAXUURzXkMDDxMbxuEeWVjdRCDcLcBhBY=".into(),
@@ -350,7 +350,7 @@ mod tests {
         );
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn fetch_header_integrity_out_of_order() {
         use crate::utils::tests::{out_of_order, OutOfOrderState};
         use futures::future::BoxFuture;
@@ -381,7 +381,7 @@ mod tests {
         );
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn fetch_header_integrity_ok_none() {
         let mut fetcher = FakeIntegrityFetcher(Err("some error".into()));
         let url = Url::parse("https://foo.com").unwrap();

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -27,7 +27,6 @@ clap = { version = "3.1.17", features = ["derive"] }
 cloudflare = "0.9.1"
 ctrlc = "3.2.2"
 der-parser = { version = "7.0.0", features = ["bigint", "serialize"] }
-futures = { version = "0.3.21", features = ["executor"] }
 http = "0.2.7"
 hyper = { version = "0.14.18", features = ["client", "http2"]}
 hyper-tls = "0.5.0"

--- a/tools/src/commands/mod.rs
+++ b/tools/src/commands/mod.rs
@@ -17,9 +17,9 @@ mod gen_config;
 mod gen_dev_cert;
 mod gen_sxg;
 
+use super::tokio_block_on as block_on;
 use anyhow::Result;
 use clap::Parser;
-use futures::executor::block_on;
 
 #[derive(Parser)]
 enum SubCommand {


### PR DESCRIPTION
* Replace `futures::executor::block_on` by `tokio` executors.
* Replace `#[async_std::test]` with `#[tokio::test]`.
* Close #163.