### PR TITLE
Allow SXG worker to store multiple certificate chains

### DIFF
--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -24,18 +24,21 @@ use fetcher::FastlyFetcher;
 use once_cell::sync::Lazy;
 use std::convert::TryInto;
 use sxg_rs::{
+    crypto::CertificateChain,
     headers::{AcceptFilter, Headers},
     http::HeaderFields,
     PresetContent,
 };
 
 pub static WORKER: Lazy<::sxg_rs::SxgWorker> = Lazy::new(|| {
-    ::sxg_rs::SxgWorker::new(
-        include_str!("../config.yaml"),
+    let mut worker = ::sxg_rs::SxgWorker::new(include_str!("../config.yaml")).unwrap();
+    let certificate = CertificateChain::from_pem_files(&[
         include_str!("../../credentials/cert.pem"),
         include_str!("../../credentials/issuer.pem"),
-    )
-    .unwrap()
+    ])
+    .unwrap();
+    worker.add_certificate(certificate);
+    worker
 });
 
 fn binary_response(status_code: StatusCode, content_type: Mime, body: &[u8]) -> Response {

--- a/sxg_rs/src/crypto.rs
+++ b/sxg_rs/src/crypto.rs
@@ -180,6 +180,8 @@ pub struct SingleCertificate {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CertificateChain {
     pub end_entity: SingleCertificate,
+    /// `issuers` are sorted as Secion 7.4.2 in RFC-4346.
+    /// For example, the root certificate is the last one.
     pub issuers: Vec<SingleCertificate>,
     #[serde(with = "crate::serde_helpers::base64")]
     pub end_entity_sha256: Vec<u8>,
@@ -188,6 +190,9 @@ pub struct CertificateChain {
 
 impl CertificateChain {
     const TAG: &'static str = "CERTIFICATE";
+    /// Parse `CertificateChain` from multiple PEM files.
+    /// Each input file may contain multiple PEM certificates.
+    /// Input files must be sorted like `[cert_pem, issuer_pem, root_pem]`.
     pub fn from_pem_files(pem_files: &[&str]) -> Result<Self> {
         let mut pem_items = vec![];
         for current_file in pem_files {

--- a/sxg_rs/src/crypto.rs
+++ b/sxg_rs/src/crypto.rs
@@ -171,6 +171,85 @@ impl Serialize for EcPrivateKey {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SingleCertificate {
+    #[serde(with = "crate::serde_helpers::base64")]
+    pub der: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CertificateChain {
+    pub end_entity: SingleCertificate,
+    pub issuers: Vec<SingleCertificate>,
+    #[serde(with = "crate::serde_helpers::base64")]
+    pub end_entity_sha256: Vec<u8>,
+    pub basename: String,
+}
+
+impl CertificateChain {
+    const TAG: &'static str = "CERTIFICATE";
+    pub fn from_pem_files(pem_files: &[&str]) -> Result<Self> {
+        let mut pem_items = vec![];
+        for current_file in pem_files {
+            let items_in_current_file = ::pem::parse_many(current_file).map_err(Error::new)?;
+            pem_items.extend_from_slice(&items_in_current_file);
+        }
+        let der_items = Self::take_certificate_contents(pem_items)?;
+        let mut der_items = der_items.into_iter();
+        let end_entity = der_items
+            .next()
+            .ok_or_else(|| Error::msg("Expecting PEM files to contain at least one certificate"))?;
+        let issuers = der_items.collect();
+        let end_entity_sha256 = HashAlgorithm::Sha256.digest(&end_entity.der);
+        Ok(CertificateChain {
+            end_entity,
+            issuers,
+            basename: base64::encode_config(&end_entity_sha256, base64::URL_SAFE_NO_PAD),
+            end_entity_sha256,
+        })
+    }
+    pub fn create_cert_cbor(&self, end_entity_ocsp_der: &[u8]) -> Vec<u8> {
+        use crate::cbor::DataItem;
+        let mut cert_cbor = vec![
+            DataItem::TextString("📜⛓"),
+            DataItem::Map(vec![
+                (
+                    DataItem::TextString("cert"),
+                    DataItem::ByteString(&self.end_entity.der),
+                ),
+                (
+                    DataItem::TextString("ocsp"),
+                    DataItem::ByteString(end_entity_ocsp_der),
+                ),
+            ]),
+        ];
+        for issuer in self.issuers.iter() {
+            cert_cbor.push(DataItem::Map(vec![(
+                DataItem::TextString("cert"),
+                DataItem::ByteString(&issuer.der),
+            )]));
+        }
+
+        let cert_cbor = DataItem::Array(cert_cbor);
+        cert_cbor.serialize()
+    }
+    fn take_certificate_contents(pem_items: Vec<::pem::Pem>) -> Result<Vec<SingleCertificate>> {
+        pem_items
+            .into_iter()
+            .map(|pem_item| {
+                const TAG: &str = "CERTIFICATE";
+                if pem_item.tag == TAG {
+                    Ok(SingleCertificate {
+                        der: pem_item.contents,
+                    })
+                } else {
+                    Err(anyhow!("Expecting {}, found {}", Self::TAG, pem_item.tag))
+                }
+            })
+            .collect::<Result<_>>()
+    }
+}
+
 #[derive(Clone, Copy)]
 pub enum HashAlgorithm {
     Sha1,

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -52,6 +52,8 @@ use url::Url;
 #[derive(Debug)]
 pub struct SxgWorker {
     config: Config,
+    /// Each new certificate is pushed to the back of the deque.
+    /// The back certificate the the latest one.
     certificates: VecDeque<CertificateChain>,
 }
 

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::crypto::CertificateChain;
 use crate::headers::AcceptFilter;
 use crate::http::HttpResponse;
 use crate::process_html::ProcessHtmlOption;
@@ -54,7 +55,10 @@ extern "C" {
 impl WasmWorker {
     #[wasm_bindgen(constructor)]
     pub fn new(config_yaml: &str, cert_pem: &str, issuer_pem: &str) -> Result<WasmWorker, JsValue> {
-        let sxg_worker = SxgWorker::new(config_yaml, cert_pem, issuer_pem).map_err(to_js_error)?;
+        let mut sxg_worker = SxgWorker::new(config_yaml).map_err(to_js_error)?;
+        let certificate =
+            CertificateChain::from_pem_files(&[cert_pem, issuer_pem]).map_err(to_js_error)?;
+        sxg_worker.add_certificate(certificate);
         Ok(WasmWorker(Arc::new(sxg_worker)))
     }
     #[wasm_bindgen(js_name=updateOcspInStorage)]


### PR DESCRIPTION
Motivation
`SxgWorker` has been using `cert_der` and `issuer_der` as member variables. However, if a new certificate chain is issued, the previous certificate chain will get dropped, and the SXGs generated by previous certificate chain will be invalid.

Changes
* Define a new struct `CertificateChain`, which internally stores one `cert_der` and multiple `issuer_der`.
* Make certificate chain parsing to be more flexible, accepting any number of input files. Previously, the `cert.pem` and `issuer.pem` must be two files.
* Remove certificate parameters from the constructor of `SxgWorker`. The user must call `add_certificate()` after constructing.
* Change to router code to check certificate name when generating cert-cbor.
* Move `SxgWorker::create_cert_cbor()` as `CertificateChain::create_cert_cbor()`.
