### PR TITLE
Allow SXGs to Vary by Cookie.

### DIFF
--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -134,7 +134,11 @@ impl Headers {
             if let Some(vary) = self.0.get("vary") {
                 if let Ok(directives) = parse_vary_header(vary) {
                     if directives.contains(&"*") {
-                        return Err(anyhow!(r#"The response may vary by anything."#));
+                        return Err(anyhow!(
+                            "The response may vary by anything,\
+                            because its \"vary\" header is \"{}\".",
+                            vary
+                        ));
                     }
                 }
             }

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -133,10 +133,8 @@ impl Headers {
             // TODO: Remove this section once https://crbug.com/1250532 is fixed in most clients.
             if let Some(vary) = self.0.get("vary") {
                 if let Ok(directives) = parse_vary_header(vary) {
-                    if directives.contains(&"*")
-                        || directives.iter().any(|d| d.eq_ignore_ascii_case("cookie"))
-                    {
-                        return Err(anyhow!(r#"The response may vary by cookie."#));
+                    if directives.contains(&"*") {
+                        return Err(anyhow!(r#"The response may vary by anything."#));
                     }
                 }
             }

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -16,7 +16,7 @@ use crate::header_integrity::HeaderIntegrityFetcher;
 use crate::http::HeaderFields;
 use crate::http_parser::{
     media_type::MediaType, parse_accept_header, parse_cache_control_header,
-    parse_content_type_header,
+    parse_content_type_header, parse_vary_header,
 };
 use crate::link::process_link_header;
 use crate::MAX_PAYLOAD_SIZE;
@@ -130,11 +130,14 @@ impl Headers {
                     return Err(anyhow!(r#"The {} header is "{}"."#, k, v));
                 }
             }
-            // https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
-            // https://datatracker.ietf.org/doc/html/rfc7234#section-4.1
+            // TODO: Remove this section once https://crbug.com/1250532 is fixed in most clients.
             if let Some(vary) = self.0.get("vary") {
-                if vary == "*" {
-                    return Err(anyhow!(r#"The response may vary by anything."#));
+                if let Ok(directives) = parse_vary_header(vary) {
+                    if directives.contains(&"*")
+                        || directives.iter().any(|d| d.eq_ignore_ascii_case("cookie"))
+                    {
+                        return Err(anyhow!(r#"The response may vary by cookie."#));
+                    }
                 }
             }
         }

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -22,8 +22,6 @@ pub mod srcset;
 use anyhow::{Error, Result};
 use base::ows;
 use nom::{
-    branch::alt,
-    bytes::complete::tag,
     character::complete::char as char1,
     combinator::eof,
     multi::separated_list0,
@@ -70,34 +68,14 @@ pub fn parse_link_header(input: &str) -> Result<Vec<link::Link>> {
     parse_vec(input, link::link)
 }
 
-// https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
-pub fn parse_vary_header(input: &str) -> Result<Vec<&str>> {
-    parse_vec(input, |input| {
-        alt((
-            tag("*"),
-            // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
-            base::token,
-        ))(input)
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn vary() {
-        assert_eq!(
-            parse_vary_header("*  , cookie").unwrap(),
-            vec!["*", "cookie"]
-        );
-        assert!(parse_vary_header("tokens only; no spaces or semicolons allowed").is_err());
-    }
     #[test]
     fn incomplete_is_err() {
         assert!(parse_accept_header("application/signed-exchange;v=").is_err());
         assert!(parse_cache_control_header("max-age=\"3600").is_err());
         assert!(parse_content_type_header("application/signed-exchange;v=\"b3").is_err());
         assert!(parse_link_header(r#"</foo>;bar="baz \""#).is_err());
-        assert!(parse_vary_header("incomplete,").is_err());
     }
 }

--- a/sxg_rs/src/http_parser/mod.rs
+++ b/sxg_rs/src/http_parser/mod.rs
@@ -22,6 +22,8 @@ pub mod srcset;
 use anyhow::{Error, Result};
 use base::ows;
 use nom::{
+    branch::alt,
+    bytes::complete::tag,
     character::complete::char as char1,
     combinator::eof,
     multi::separated_list0,
@@ -68,14 +70,34 @@ pub fn parse_link_header(input: &str) -> Result<Vec<link::Link>> {
     parse_vec(input, link::link)
 }
 
+// https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.4
+pub fn parse_vary_header(input: &str) -> Result<Vec<&str>> {
+    parse_vec(input, |input| {
+        alt((
+            tag("*"),
+            // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+            base::token,
+        ))(input)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn vary() {
+        assert_eq!(
+            parse_vary_header("*  , cookie").unwrap(),
+            vec!["*", "cookie"]
+        );
+        assert!(parse_vary_header("tokens only; no spaces or semicolons allowed").is_err());
+    }
     #[test]
     fn incomplete_is_err() {
         assert!(parse_accept_header("application/signed-exchange;v=").is_err());
         assert!(parse_cache_control_header("max-age=\"3600").is_err());
         assert!(parse_content_type_header("application/signed-exchange;v=\"b3").is_err());
         assert!(parse_link_header(r#"</foo>;bar="baz \""#).is_err());
+        assert!(parse_vary_header("incomplete,").is_err());
     }
 }


### PR DESCRIPTION
SXGs with `Vary: Cookie` will only be shown to users without cookies for the
signed domain, per https://crbug.com/1250532. This will soon be allowed by
https://github.com/google/webpackager/blob/main/docs/cache_requirements.md.