### PR TITLE
Use Arc instead of Box in SxgWorker and Runtime

### DIFF
--- a/sxg_rs/src/acme/mod.rs
+++ b/sxg_rs/src/acme/mod.rs
@@ -654,7 +654,7 @@ mod tests {
     async fn workflow() {
         let (fetcher, mut server) = crate::fetcher::mock_fetcher::create();
         let runtime = Runtime {
-            fetcher: Box::new(fetcher),
+            fetcher: std::sync::Arc::new(fetcher),
             ..Default::default()
         };
         let public_key = EcPublicKey {

--- a/sxg_rs/src/acme/state_machine.rs
+++ b/sxg_rs/src/acme/state_machine.rs
@@ -239,6 +239,7 @@ mod tests {
     };
     use super::*;
     use crate::storage::{InMemoryStorage, Storage};
+    use std::sync::Arc;
     use std::time::UNIX_EPOCH;
     const ACCOUNT: &str = r#"{
         "serverDirectoryUrl": "https://acme.server/",
@@ -251,7 +252,7 @@ mod tests {
     async fn new_storage_returns_default_state() {
         let storage = InMemoryStorage::new();
         let runtime = Runtime {
-            storage: Box::new(storage),
+            storage: Arc::new(storage),
             ..Default::default()
         };
         let state = read_current_state(&runtime).await.unwrap();
@@ -263,7 +264,7 @@ mod tests {
         let storage = InMemoryStorage::new();
         storage.write(ACME_STORAGE_KEY, "asdf").await.unwrap();
         let runtime = Runtime {
-            storage: Box::new(storage),
+            storage: Arc::new(storage),
             ..Default::default()
         };
         let state = read_current_state(&runtime).await.unwrap();
@@ -293,11 +294,11 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH,
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -335,7 +336,7 @@ mod tests {
         let (fetcher, _server) = crate::fetcher::mock_fetcher::create();
         let server_thread = async {};
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -351,7 +352,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(59),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -389,7 +390,7 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -405,7 +406,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(61),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -444,7 +445,7 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -460,7 +461,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(61),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -498,7 +499,7 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -514,7 +515,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(61),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -552,7 +553,7 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -568,7 +569,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(61),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -607,7 +608,7 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -623,7 +624,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(61),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();
@@ -670,7 +671,7 @@ mod tests {
                 .unwrap();
         };
         let client_thread = async {
-            let storage = Box::new(InMemoryStorage::new());
+            let storage = Arc::new(InMemoryStorage::new());
             const VALUE: &str = r#"{
                 "certificate": null,
                 "task": {
@@ -686,7 +687,7 @@ mod tests {
             let runtime = Runtime {
                 storage,
                 now: UNIX_EPOCH + Duration::from_secs(61),
-                fetcher: Box::new(fetcher),
+                fetcher: Arc::new(fetcher),
                 ..Default::default()
             };
             let account: Account = serde_json::from_str(ACCOUNT).unwrap();

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -46,12 +46,13 @@ use http_cache::HttpCache;
 use runtime::Runtime;
 use serde::Serialize;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
 #[derive(Debug)]
 pub struct SxgWorker {
-    config: Config,
+    config: Arc<Config>,
     /// Each new certificate is pushed to the back of the deque.
     /// The back certificate the the latest one.
     certificates: VecDeque<CertificateChain>,
@@ -77,10 +78,10 @@ pub(crate) const MAX_PAYLOAD_SIZE: usize = 8_000_000;
 
 impl SxgWorker {
     pub fn new(config_yaml: &str) -> Result<Self> {
-        let config = Config::new(config_yaml)?;
+        let config = Arc::new(Config::new(config_yaml)?);
         Ok(Self::from_parsed(config))
     }
-    pub fn from_parsed(config: Config) -> Self {
+    pub fn from_parsed(config: Arc<Config>) -> Self {
         SxgWorker {
             config,
             certificates: VecDeque::new(),

--- a/sxg_rs/src/runtime/mod.rs
+++ b/sxg_rs/src/runtime/mod.rs
@@ -18,24 +18,25 @@ pub mod js_runtime;
 use crate::fetcher::{Fetcher, NullFetcher};
 use crate::signature::{mock_signer::MockSigner, Signer};
 use crate::storage::{InMemoryStorage, Storage};
+use std::sync::Arc;
 use std::time::SystemTime;
 
 pub struct Runtime {
     pub now: SystemTime,
-    pub fetcher: Box<dyn Fetcher>,
-    pub storage: Box<dyn Storage>,
-    pub sxg_signer: Box<dyn Signer>,
-    pub acme_signer: Box<dyn Signer>,
+    pub fetcher: Arc<dyn Fetcher>,
+    pub storage: Arc<dyn Storage>,
+    pub sxg_signer: Arc<dyn Signer>,
+    pub acme_signer: Arc<dyn Signer>,
 }
 
 impl Default for Runtime {
     fn default() -> Self {
         Runtime {
             now: SystemTime::UNIX_EPOCH,
-            fetcher: Box::new(NullFetcher),
-            storage: Box::new(InMemoryStorage::default()),
-            sxg_signer: Box::new(MockSigner),
-            acme_signer: Box::new(MockSigner),
+            fetcher: Arc::new(NullFetcher),
+            storage: Arc::new(InMemoryStorage::default()),
+            sxg_signer: Arc::new(MockSigner),
+            acme_signer: Arc::new(MockSigner),
         }
     }
 }


### PR DESCRIPTION
It would be more flexible to use Arc instead of Box:

* Sharing configs between workers is cheaper as most of the websites can have the same config.
* Sharing some fields in the runtime is cheaper (e.g. fetcher)

Note: it would properly better if sxg_rs uses reference with lifetime instead but it is a little bit more tricky to refactor WasmWorker.