### PR TITLE
Use a mock signer when private key is not set

### DIFF
--- a/cloudflare_worker/worker/src/bindings.d.ts
+++ b/cloudflare_worker/worker/src/bindings.d.ts
@@ -22,7 +22,7 @@ declare global {
   const HTML_HOST: string;
   const ISSUER_PEM: string;
   const OCSP: KVNamespace;
-  const PRIVATE_KEY_JWK: string;
+  const PRIVATE_KEY_JWK: string | undefined;
   const ACME_PRIVATE_KEY_JWK: string;
   const ACME_ACCOUNT: string;
   const SXG_CONFIG: string;

--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -51,12 +51,9 @@ const workerPromise = (async () => {
   return worker;
 })();
 
-if (typeof PRIVATE_KEY_JWK === 'undefined') {
-  throw 'The wrangler secret PRIVATE_KEY_JWK is not set.';
-}
 const sxgSigner = createSignerFromJwk(
   crypto.subtle,
-  JSON.parse(PRIVATE_KEY_JWK)
+  typeof PRIVATE_KEY_JWK === 'string' ? JSON.parse(PRIVATE_KEY_JWK) : null
 );
 
 addEventListener('fetch', (event: FetchEvent) => {

--- a/typescript_utilities/src/signer.ts
+++ b/typescript_utilities/src/signer.ts
@@ -20,7 +20,16 @@ export type Signer = (message: Uint8Array) => Promise<Uint8Array>;
 // TODO: give `subtle` parameter a type that is recognized
 // in both NodeJs and Browser.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function fromJwk(subtle: any, jwk: Object): Signer {
+export function fromJwk(subtle: any, jwk: object | null): Signer {
+  if (jwk === null) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return async function signer(_message: Uint8Array): Promise<Uint8Array> {
+      console.error(
+        'Creating an empty signature, because the wrangler secret PRIVATE_KEY_JWK is not set'
+      );
+      return new Uint8Array(64);
+    };
+  }
   const privateKeyPromise = (async function initPrivateKey() {
     return await subtle.importKey(
       'jwk',


### PR DESCRIPTION
* No longer throw an error when `PRIVATE_KEY_JWK` is not set, because throwing an error at global scope terminates most `wrangler` commands.
* When `PRIVATE_KEY_JWK` is not set, the worker will generate an invalid signature, and print an error to log.