### PR TITLE
Write new state only when it's different from old state

### DIFF
--- a/sxg_rs/src/acme/mod.rs
+++ b/sxg_rs/src/acme/mod.rs
@@ -50,7 +50,7 @@ pub struct Account {
 
 /// The runtime context of an ongoing ACME certificate request, which is
 /// waiting for HTTP challenge.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OngoingOrder {
     authorization_url: String,
     challenge_url: String,

--- a/sxg_rs/src/acme/state_machine.rs
+++ b/sxg_rs/src/acme/state_machine.rs
@@ -24,13 +24,13 @@ use std::time::{Duration, SystemTime};
 
 const ACME_STORAGE_KEY: &str = "ACME";
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AcmeStorageData {
     pub certificates: Vec<String>,
     task: Option<Task>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Task {
     order: OngoingOrder,
     schedule: Schedule,
@@ -211,7 +211,9 @@ pub async fn update_state(runtime: &Runtime, account: &Account) -> Result<()> {
     .await;
     match result {
         Ok(()) => {
-            write_state(runtime, &new_state).await?;
+            if old_state != new_state {
+                write_state(runtime, &new_state).await?;
+            }
             Ok(())
         }
         Err(e) => {


### PR DESCRIPTION
Significantly reduce the number of writing to the online KV storage.