### PR TITLE
Move OCSP update to be after ACME update

### DIFF
--- a/cloudflare_worker/worker/src/index.ts
+++ b/cloudflare_worker/worker/src/index.ts
@@ -134,8 +134,8 @@ function createRuntime() {
 async function updateStateMachine() {
   const worker = await workerPromise;
   const runtime = createRuntime();
-  await worker.updateOcspInStorage(runtime);
   await worker.updateAcmeStateMachine(runtime, ACME_ACCOUNT);
+  await worker.updateOcspInStorage(runtime);
 }
 
 async function handleRequest(request: Request) {


### PR DESCRIPTION
The execution of a worker has some probability to be terminated (e.g. exceeding the executing time limit), hence we re-order the steps, assuming that the ACME state machine has priority over OCSP state machine.