### PR TITLE
Change async fns to return Future + Send.

### DIFF
--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -36,3 +36,7 @@ serde = { version = "1.0.140", features = ["derive"] }
 serde_yaml = "0.8.26"
 sxg_rs = { path = "../sxg_rs", features = ["rust_signer"] }
 tokio = { version = "1.20.1", features = ["rt"] }
+
+[features]
+# Unsupported, but necessary to make `cargo some-cmd --all-features` happy.
+wasm = ["sxg_rs/wasm"]

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -37,7 +37,8 @@ impl FastlyFetcher {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl Fetcher for FastlyFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
         let request: ::http::request::Request<Vec<u8>> = request.try_into()?;

--- a/fastly_compute/src/fetcher.rs
+++ b/fastly_compute/src/fetcher.rs
@@ -37,7 +37,7 @@ impl FastlyFetcher {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Fetcher for FastlyFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
         let request: ::http::request::Request<Vec<u8>> = request.try_into()?;

--- a/sxg_rs/src/fetcher/mock_fetcher.rs
+++ b/sxg_rs/src/fetcher/mock_fetcher.rs
@@ -53,7 +53,8 @@ pub fn create() -> (MockFetcher, MockServer) {
     (mock_fetcher, mock_server)
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl Fetcher for MockFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
         let request_url = request.url.clone();

--- a/sxg_rs/src/http_cache/mod.rs
+++ b/sxg_rs/src/http_cache/mod.rs
@@ -16,19 +16,22 @@
 pub mod js_http_cache;
 
 use crate::http::HttpResponse;
+use crate::utils::{MaybeSend, MaybeSync};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 
 /// An interface for storing HTTP responses in a cache.
-#[async_trait(?Send)]
-pub trait HttpCache {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait HttpCache: MaybeSend + MaybeSync {
     async fn get(&self, url: &str) -> Result<HttpResponse>;
     async fn put(&self, url: &str, response: &HttpResponse) -> Result<()>;
 }
 
 pub struct NullCache;
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl HttpCache for NullCache {
     async fn get(&self, _url: &str) -> Result<HttpResponse> {
         Err(anyhow!("No cache entry found in NullCache"))

--- a/sxg_rs/src/signature/mock_signer.rs
+++ b/sxg_rs/src/signature/mock_signer.rs
@@ -18,7 +18,8 @@ use async_trait::async_trait;
 
 pub struct MockSigner;
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl Signer for MockSigner {
     async fn sign(&self, _message: &[u8], format: Format) -> Result<Vec<u8>> {
         match format {

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -19,6 +19,7 @@ pub mod mock_signer;
 pub mod rust_signer;
 
 use crate::structured_header::{ParamItem, ShItem, ShParamList};
+use crate::utils::{MaybeSend, MaybeSync};
 use anyhow::{anyhow, Error, Result};
 use async_trait::async_trait;
 use der_parser::ber::{BerObject, BerObjectContent};
@@ -31,8 +32,9 @@ pub enum Format {
     EccAsn1,
 }
 
-#[async_trait(?Send)]
-pub trait Signer {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait Signer: MaybeSend + MaybeSync {
     /// Signs the message, and returns in the given format.
     async fn sign(&self, message: &[u8], format: Format) -> Result<Vec<u8>>;
 }

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -28,7 +28,7 @@ impl RustSigner {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Signer for RustSigner {
     async fn sign(&self, message: &[u8], format: Format) -> Result<Vec<u8>> {
         use p256::ecdsa::signature::Signer as _;

--- a/sxg_rs/src/signature/rust_signer.rs
+++ b/sxg_rs/src/signature/rust_signer.rs
@@ -28,7 +28,8 @@ impl RustSigner {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl Signer for RustSigner {
     async fn sign(&self, message: &[u8], format: Format) -> Result<Vec<u8>> {
         use p256::ecdsa::signature::Signer as _;

--- a/sxg_rs/src/storage/mod.rs
+++ b/sxg_rs/src/storage/mod.rs
@@ -15,14 +15,16 @@
 #[cfg(feature = "wasm")]
 pub mod js_storage;
 
+use crate::utils::{MaybeSend, MaybeSync};
 use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-#[async_trait(?Send)]
-pub trait Storage {
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+pub trait Storage: MaybeSend + MaybeSync {
     async fn read(&self, k: &str) -> Result<Option<String>>;
     async fn write(&self, k: &str, v: &str) -> Result<()>;
 }
@@ -35,7 +37,8 @@ impl InMemoryStorage {
     }
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl Storage for InMemoryStorage {
     async fn read(&self, k: &str) -> Result<Option<String>> {
         let guard = self.0.read().await;

--- a/sxg_rs/src/utils.rs
+++ b/sxg_rs/src/utils.rs
@@ -69,6 +69,28 @@ pub async fn await_js_promise(
         .map_err(|e| anyhow!("{:?}", e).context("JavaScript throws an error asynchronously"))
 }
 
+/// A trait for a type implements Send except when feature = "wasm".
+#[cfg(feature = "wasm")]
+pub trait MaybeSend {}
+#[cfg(feature = "wasm")]
+impl<T> MaybeSend for T {}
+
+#[cfg(not(feature = "wasm"))]
+pub trait MaybeSend: Send {}
+#[cfg(not(feature = "wasm"))]
+impl<T: Send> MaybeSend for T {}
+
+/// A trait for a type implements Sync except when feature = "wasm".
+#[cfg(feature = "wasm")]
+pub trait MaybeSync {}
+#[cfg(feature = "wasm")]
+impl<T> MaybeSync for T {}
+
+#[cfg(not(feature = "wasm"))]
+pub trait MaybeSync: Sync {}
+#[cfg(not(feature = "wasm"))]
+impl<T: Sync> MaybeSync for T {}
+
 // #[warn(clippy::too_many_arguments)]
 pub async fn signed_headers_and_payload(
     fallback_url: &Url,

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -39,3 +39,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 url = "2.2.2"
 warp = "0.3.2"
 wrangler = "1.19.12"
+
+[features]
+# Unsupported, but necessary to make `cargo some-cmd --all-features` happy.
+wasm = ["sxg_rs/wasm"]

--- a/tools/src/runtime/hyper_fetcher.rs
+++ b/tools/src/runtime/hyper_fetcher.rs
@@ -41,7 +41,8 @@ impl Default for HyperFetcher {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl Fetcher for HyperFetcher {
     async fn fetch(&self, request: SxgRsRequest) -> Result<SxgRsResponse> {
         let request: http::Request<Vec<u8>> = request

--- a/tools/src/runtime/hyper_fetcher.rs
+++ b/tools/src/runtime/hyper_fetcher.rs
@@ -41,7 +41,7 @@ impl Default for HyperFetcher {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Fetcher for HyperFetcher {
     async fn fetch(&self, request: SxgRsRequest) -> Result<SxgRsResponse> {
         let request: http::Request<Vec<u8>> = request

--- a/tools/src/runtime/openssl_signer.rs
+++ b/tools/src/runtime/openssl_signer.rs
@@ -23,7 +23,8 @@ pub enum OpensslSigner<'a> {
     Hmac(&'a [u8]),
 }
 
-#[async_trait]
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
 impl<'a> Signer for OpensslSigner<'a> {
     async fn sign(&self, message: &[u8], format: SignatureFormat) -> Result<Vec<u8>> {
         let tmp_file = execute_and_parse_stdout(&mut Command::new("mktemp"))?;

--- a/tools/src/runtime/openssl_signer.rs
+++ b/tools/src/runtime/openssl_signer.rs
@@ -23,7 +23,7 @@ pub enum OpensslSigner<'a> {
     Hmac(&'a [u8]),
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl<'a> Signer for OpensslSigner<'a> {
     async fn sign(&self, message: &[u8], format: SignatureFormat) -> Result<Vec<u8>> {
         let tmp_file = execute_and_parse_stdout(&mut Command::new("mktemp"))?;


### PR DESCRIPTION
Change local variables in async function to implement Send, so that they return
Futures that implement Send.

This is a prerequisite for serving SXGs in a request handler in hyper, without
relying on something like block_on or thread::spawn which could limit
concurrency.

Addresses #250.