### PR TITLE
Add a platform arg to config generator

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm install -g @cloudflare/wrangler
       - name: Gen config
         run: |
-          cargo run -p tools -- gen-config --use-ci-mode --input input.example.yaml --artifact artifact.yaml
+          cargo run -p tools -- gen-config --use-ci-mode --input input.example.yaml --artifact artifact.yaml --platform cloudflare
       - name: Build
         working-directory: cloudflare_worker
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,7 +113,7 @@ jobs:
           cargo run -p tools -- gen-dev-cert --domain example.org
       - name: Gen config
         run: |
-          cargo run -p tools -- gen-config --use-ci-mode --input input.example.yaml --artifact artifact.yaml
+          cargo run -p tools -- gen-config --use-ci-mode --input input.example.yaml --artifact artifact.yaml --platform cloudflare
       - name: Build wasm
         working-directory: cloudflare_worker
         run: |

--- a/cloudflare_worker/README.md
+++ b/cloudflare_worker/README.md
@@ -91,7 +91,7 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
 
 1. Run following command.
    ```bash
-   cargo run -p tools -- gen-config --input input.yaml --artifact artifact.yaml
+   cargo run -p tools -- gen-config --input input.yaml --artifact artifact.yaml --platform cloudflare
    ```
    This command will create a `cloudflare_worker/wrangler.toml` that is used by the `wrangler` command.
 
@@ -157,7 +157,7 @@ the certificates need to be renewed every 90 days.
 
 1. Follow [these steps](../credentials/README.md#renew-certificate) to renew
    the certificate.
-1. Run `cargo run -p tools -- gen-config --input input.yaml --artifact artifact.yaml`.
+1. Run `cargo run -p tools -- gen-config --input input.yaml --artifact artifact.yaml --platform cloudflare`.
 1. Run `cloudflare_worker/publish.sh` to restart the worker.
 
 ## Uninstall

--- a/cloudflare_worker/README.md
+++ b/cloudflare_worker/README.md
@@ -72,9 +72,9 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
 
    - Replace every instance of `YOUR_DOMAIN` with your domain name. For
      example, in [`html_host`](../input.example.yaml#L18) and
-     [`routes`](../input.example.yaml#L34-L35).
+     [`routes`](../input.example.yaml#L50).
    - Put your Cloudflare account ID and zone ID in the
-     [`cloudflare` section](../input.example.yaml#L29-L30).
+     [`cloudflare` section](../input.example.yaml#L45-L46).
      To determine the IDs,
      see [this screenshot](https://forum.aapanel.com/d/3914-how-to-get-zone-id-of-cloudflare).
 
@@ -84,9 +84,9 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
    * If you are using
    [ACME](../credentials/README.md#option-1-automatic-certificate-management-environment-acme),
    you should have followed the instructions to comment the entire `pre_issued`
-   [section](../input.example.yaml#L39-L41),
+   [section](../input.example.yaml#L29-L31),
    and uncomment `create_acme_account`
-   [section](../input.example.yaml#L42-L53)
+   [section](../input.example.yaml#L32-L43)
    in `input.yaml`.
 
 1. Run following command.

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -59,7 +59,7 @@ which provide ACME service.
       * Skip all steps after the step *Request an EAB key ID and HMAC*,
         because `sxg-rs` will do them.
 
-   1. For the [certificates section](../input.example.yaml#L37-L52) in `input.yaml`,
+   1. For the [certificates section](../input.example.yaml#L28-L43) in `input.yaml`,
       comment `pre_issued` section and uncomment `create_acme_account` section.
       ```diff
        # the last few lines in input.yaml

--- a/input.example.yaml
+++ b/input.example.yaml
@@ -25,15 +25,6 @@ sxg_worker:
   strip_response_headers:
     - set-cookie
   validity_url_dirname: ".well-known/sxg-validity"
-cloudflare:
-  account_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-  zone_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-  # You can define URL patterns for the SXG worker. See Cloudflare's doc at
-  # https://developers.cloudflare.com/workers/platform/routing/routes/
-  routes:
-    - https://YOUR_DOMAIN/*
-  worker_name: sxg
-  deploy_on_workers_dev_only: false
 certificates:
   pre_issued:
     cert_file: credentials/cert.pem
@@ -50,3 +41,12 @@ certificates:
   #   eab:
   #     base64_mac_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXQ
   #     key_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+cloudflare:
+  account_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  zone_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  # You can define URL patterns for the SXG worker. See Cloudflare's doc at
+  # https://developers.cloudflare.com/workers/platform/routing/routes/
+  routes:
+    - https://YOUR_DOMAIN/*
+  worker_name: sxg
+  deploy_on_workers_dev_only: false

--- a/sxg_rs/src/crypto.rs
+++ b/sxg_rs/src/crypto.rs
@@ -33,7 +33,7 @@ pub fn get_der_from_pem(pem_text: &str, expected_tag: &str) -> Result<Vec<u8>> {
     ))
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EcPublicKey {
     pub crv: String,
     pub kty: String,
@@ -43,10 +43,11 @@ pub struct EcPublicKey {
     pub y: Vec<u8>,
 }
 
+#[derive(Debug, Deserialize)]
 pub struct EcPrivateKey {
-    // Only used when --feature=rust_signer.
-    #[allow(dead_code)]
+    #[serde(with = "crate::serde_helpers::base64")]
     d: Vec<u8>,
+    #[serde(flatten)]
     pub public_key: EcPublicKey,
 }
 

--- a/tools/src/commands/gen_config/cloudflare.rs
+++ b/tools/src/commands/gen_config/cloudflare.rs
@@ -140,10 +140,13 @@ pub fn main(
                     create_acme_key_and_account(acme_config, &sxg_input.html_host),
                 )?;
                 artifact.acme_account = Some(acme_account);
-                artifact.acme_private_key_instruction = Some(create_wrangler_secret_instruction(
-                    "ACME_PRIVATE_KEY_JWK",
-                    &serde_json::to_string(&acme_private_key)?,
-                ))
+                artifact.acme_private_key_instructions.insert(
+                    "cloudflare".to_string(),
+                    create_wrangler_secret_instruction(
+                        "ACME_PRIVATE_KEY_JWK",
+                        &serde_json::to_string(&acme_private_key)?,
+                    ),
+                );
             }
             wrangler_vars.acme_account = Some(serde_json::to_string(&artifact.acme_account)?);
         }

--- a/tools/src/commands/gen_config/cloudflare.rs
+++ b/tools/src/commands/gen_config/cloudflare.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{create_acme_key_and_account, read_certificate_pem_file, Artifact, SxgCertConfig};
-use crate::tokio_block_on;
+use super::{read_certificate_pem_file, Artifact, SxgCertConfig};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use sxg_rs::config::Config as SxgConfig;
@@ -134,20 +133,14 @@ pub fn main(
             wrangler_vars.cert_pem = Some(read_certificate_pem_file(cert_file)?);
             wrangler_vars.issuer_pem = Some(read_certificate_pem_file(issuer_file)?);
         }
-        SxgCertConfig::CreateAcmeAccount(acme_config) => {
-            if artifact.acme_account.is_none() {
-                let (acme_private_key, acme_account) = tokio_block_on(
-                    create_acme_key_and_account(acme_config, &sxg_input.html_host),
-                )?;
-                artifact.acme_account = Some(acme_account);
-                artifact.acme_private_key_instructions.insert(
-                    "cloudflare".to_string(),
-                    create_wrangler_secret_instruction(
-                        "ACME_PRIVATE_KEY_JWK",
-                        &serde_json::to_string(&acme_private_key)?,
-                    ),
-                );
-            }
+        SxgCertConfig::CreateAcmeAccount(_) => {
+            artifact.acme_private_key_instructions.insert(
+                "cloudflare".to_string(),
+                create_wrangler_secret_instruction(
+                    "ACME_PRIVATE_KEY_JWK",
+                    &serde_json::to_string(&artifact.acme_private_key)?,
+                ),
+            );
             wrangler_vars.acme_account = Some(serde_json::to_string(&artifact.acme_account)?);
         }
     };

--- a/tools/src/commands/gen_config/mod.rs
+++ b/tools/src/commands/gen_config/mod.rs
@@ -44,7 +44,7 @@ pub struct Opts {
     #[clap(long)]
     use_ci_mode: bool,
     #[clap(arg_enum, long)]
-    platform: Platform,
+    platform: Option<Platform>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -203,7 +203,7 @@ pub fn main(opts: Opts) -> Result<()> {
     };
 
     match opts.platform {
-        Platform::Cloudflare => {
+        Some(Platform::Cloudflare) => {
             cloudflare::main(
                 opts.use_ci_mode,
                 &input.sxg_worker,
@@ -214,6 +214,7 @@ pub fn main(opts: Opts) -> Result<()> {
                 &mut artifact,
             )?;
         }
+        None => (),
     };
 
     std::fs::write(

--- a/tools/src/commands/gen_config/mod.rs
+++ b/tools/src/commands/gen_config/mod.rs
@@ -82,6 +82,7 @@ pub struct EabConfig {
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Artifact {
     acme_account: Option<AcmeAccount>,
+    acme_private_key: Option<EcPrivateKey>,
     acme_private_key_instructions: BTreeMap<String, String>,
     cloudflare_kv_namespace_id: Option<String>,
 }


### PR DESCRIPTION
* Add `--platform` arg to CLI tool `cargo run gen-config`. Hence in the future, it would be possible to generate config for other platforms.
* Move the execution of `tokio_block_on(create_acme_key_and_account(...))` from `gen_config/cloudflare.rs` to `gen_config/mod.rs`, so that the ACME account is created no matter which target platform is selected.