### PR TITLE
Remove duplicate code of creating ACME account

### DIFF
--- a/tools/src/commands/apply_acme_cert.rs
+++ b/tools/src/commands/apply_acme_cert.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::linux_commands::{create_certificate_request_pem, read_or_create_private_key_pem};
+use super::gen_config::read_artifact;
 use crate::runtime::hyper_fetcher::HyperFetcher;
-use anyhow::{Error, Result};
+use anyhow::Result;
 use clap::Parser;
-use sxg_rs::acme::directory::Directory;
-use sxg_rs::acme::eab::create_external_account_binding;
 use sxg_rs::acme::state_machine::{
     get_challenge_token_and_answer, update_state as update_acme_state_machine,
 };
@@ -28,25 +26,8 @@ use warp::Filter;
 pub struct Opts {
     #[clap(long)]
     port: u16,
-    /// Directory URL of ACME server
     #[clap(long)]
-    acme_server: String,
-    #[clap(long)]
-    email: String,
-    #[clap(long)]
-    domain: String,
-    #[clap(long, default_value_t=String::from("acme_account_private_key.pem"))]
-    acme_account_private_key_file: String,
-    #[clap(long, default_value_t=String::from("privkey.pem"))]
-    sxg_private_key_file: String,
-    #[clap(long, default_value_t=String::from("cert.csr"))]
-    sxg_cert_request_file: String,
-    #[clap(long)]
-    agreed_terms_of_service: String,
-    #[clap(long)]
-    eab_mac_key: Option<String>,
-    #[clap(long)]
-    eab_key_id: Option<String>,
+    artifact: String,
 }
 
 fn start_warp_server(port: u16, answer: String) -> tokio::sync::oneshot::Sender<()> {
@@ -62,64 +43,14 @@ fn start_warp_server(port: u16, answer: String) -> tokio::sync::oneshot::Sender<
 }
 
 pub async fn main(opts: Opts) -> Result<()> {
-    let acme_private_key = {
-        let private_key_pem = read_or_create_private_key_pem(&opts.acme_account_private_key_file)?;
-        sxg_rs::crypto::EcPrivateKey::from_sec1_pem(&private_key_pem)?
-    };
-    let sxg_cert_request_der = {
-        read_or_create_private_key_pem(&opts.sxg_private_key_file)?;
-        let cert_request_pem = create_certificate_request_pem(
-            &opts.domain,
-            &opts.sxg_private_key_file,
-            &opts.sxg_cert_request_file,
-        )?;
-        sxg_rs::crypto::get_der_from_pem(&cert_request_pem, "CERTIFICATE REQUEST")?
-    };
+    let artifact = read_artifact(&opts.artifact)?;
+    let acme_account = artifact.acme_account.unwrap();
+    let acme_private_key = artifact.acme_private_key.unwrap();
     let mut runtime = sxg_rs::runtime::Runtime {
         acme_signer: Box::new(acme_private_key.create_signer()?),
         fetcher: Box::new(HyperFetcher::new()),
         ..Default::default()
     };
-    let external_account_binding = match (&opts.eab_key_id, &opts.eab_mac_key) {
-        (Some(eab_key_id), Some(eab_mac_key)) => {
-            let eab_mac_key = base64::decode_config(eab_mac_key, base64::URL_SAFE_NO_PAD)?;
-            let eab_signer = crate::runtime::openssl_signer::OpensslSigner::Hmac(&eab_mac_key);
-            let new_account_url = Directory::from_url(&opts.acme_server, runtime.fetcher.as_ref())
-                .await?
-                .0
-                .new_account;
-            let eab = create_external_account_binding(
-                sxg_rs::acme::jws::Algorithm::HS256,
-                eab_key_id,
-                &new_account_url,
-                &acme_private_key.public_key,
-                &eab_signer,
-            )
-            .await?;
-            Some(eab)
-        }
-        (None, None) => None,
-        _ => {
-            return Err(Error::msg(
-                "To use External Account Binding, \
-                please provide both \"eab-key-id\" and \"eab-mac-key\".",
-            ))
-        }
-    };
-    let acme_account = sxg_rs::acme::create_account(
-        sxg_rs::acme::AccountSetupParams {
-            directory_url: opts.acme_server.clone(),
-            agreed_terms_of_service: &opts.agreed_terms_of_service,
-            external_account_binding,
-            email: &opts.email,
-            domain: opts.domain.clone(),
-            public_key: acme_private_key.public_key,
-            cert_request_der: sxg_cert_request_der,
-        },
-        runtime.fetcher.as_ref(),
-        runtime.acme_signer.as_ref(),
-    )
-    .await?;
     let challenge_answer = loop {
         runtime.now = std::time::SystemTime::now();
         update_acme_state_machine(&runtime, &acme_account).await?;

--- a/tools/src/commands/gen_config/mod.rs
+++ b/tools/src/commands/gen_config/mod.rs
@@ -81,10 +81,10 @@ pub struct EabConfig {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Artifact {
-    acme_account: Option<AcmeAccount>,
-    acme_private_key: Option<EcPrivateKey>,
-    acme_private_key_instructions: BTreeMap<String, String>,
-    cloudflare_kv_namespace_id: Option<String>,
+    pub acme_account: Option<AcmeAccount>,
+    pub acme_private_key: Option<EcPrivateKey>,
+    pub acme_private_key_instructions: BTreeMap<String, String>,
+    pub cloudflare_kv_namespace_id: Option<String>,
 }
 
 // Set working directory to the root folder of the "sxg-rs" repository.
@@ -175,7 +175,7 @@ async fn create_acme_key_and_account(
     Ok((acme_private_key, account))
 }
 
-fn read_artifact(file_name: &str) -> Result<Artifact> {
+pub fn read_artifact(file_name: &str) -> Result<Artifact> {
     let file_content = std::fs::read_to_string(file_name)?;
     let artifact = serde_yaml::from_str(&file_content)?;
     Ok(artifact)


### PR DESCRIPTION
Remove ACME args from `apply-acme-cert`.
Now `apply-acme-cert` reads ACME data from `artifact.yaml`, which could be generated by `gen-config`.