### PR TITLE
Update serde_yaml to 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,12 +1527,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
@@ -1733,12 +1727,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1943,7 +1937,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cssparser",
  "encoding_rs",
- "hashbrown 0.12.0",
+ "hashbrown",
  "lazy_static",
  "lazycell",
  "memchr",
@@ -3163,14 +3157,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
 dependencies = [
  "indexmap",
+ "itoa 1.0.1",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3950,6 +3945,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
 
 [[package]]
 name = "untrusted"

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -64,10 +64,10 @@ which provide ACME service.
       ```diff
        # the last few lines in input.yaml
        certificates:
-      -  pre_issued:
+      -  !pre_issued:
       -     cert_file: credentials/cert.pem
       -     issuer_file: credentials/issuer.pem
-      -  # create_acme_account:
+      -  # !create_acme_account:
       -  #   server_url: https://dv-sxg.acme-v02.api.pki.goog/directory
       -  #   contact_email: YOUR_EMAIL
       -  #   agreed_terms_of_service: https://pki.goog/GTS-SA.pdf
@@ -75,10 +75,10 @@ which provide ACME service.
       -  #   eab:
       -  #      key_id: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXQ
       -  #      base64_mac_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-      +  # pre_issued:
+      +  # !pre_issued:
       +  #    cert_file: credentials/cert.pem
       +  #    issuer_file: credentials/issuer.pem
-      +  create_acme_account:
+      +  !create_acme_account:
       +    server_url: https://dv-sxg.acme-v02.api.pki.goog/directory
       +    contact_email: YOUR_EMAIL
       +    agreed_terms_of_service: https://pki.goog/GTS-SA.pdf

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -33,7 +33,7 @@ log-fastly = "0.8.6"
 once_cell = "1.13.0"
 pem = "1.1.0"
 serde = { version = "1.0.140", features = ["derive"] }
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.4"
 sxg_rs = { path = "../sxg_rs", features = ["rust_signer"] }
 tokio = { version = "1.20.1", features = ["rt"] }
 

--- a/input.example.yaml
+++ b/input.example.yaml
@@ -26,11 +26,11 @@ sxg_worker:
     - set-cookie
   validity_url_dirname: ".well-known/sxg-validity"
 certificates:
-  pre_issued:
+  !pre_issued
     cert_file: credentials/cert.pem
     issuer_file: credentials/issuer.pem
   # # If this section is uncommented, an ACME account will be created.
-  # create_acme_account:
+  # !create_acme_account:
   #   server_url: https://dv-sxg.acme-v02.api.pki.goog/directory
   #   contact_email: YOUR_EMAIL
   #   # Read and aggree the terms of service before uncommenting next line.

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -47,7 +47,7 @@ pem = "1.1.0"
 p256 = { version = "0.11.1", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.82"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.4"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
 tokio = { version = "1.20.1", features = ["macros", "parking_lot", "sync", "time"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -32,7 +32,7 @@ hyper-tls = "0.5.0"
 pem = "1.1.0"
 serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.82"
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.4"
 sxg_rs = { path = "../sxg_rs", features = ["rust_signer"] }
 toml = "0.5.9"
 tokio = { version = "1.20.1", features = ["full"] }


### PR DESCRIPTION
`serde_yaml` has a  [breaking changes](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0#:~:text=Serialization%20of%20enum%20variants) that requires enum variants to be based on YAML's `!Tag` syntax.

The breaking change is the reason why #333 is failing [tests](https://github.com/google/sxg-rs/runs/7655073417?check_suite_focus=true).