### PR TITLE
Derive Eq for structs deriving PartialEq

### DIFF
--- a/sxg_rs/src/http.rs
+++ b/sxg_rs/src/http.rs
@@ -53,7 +53,7 @@ impl TryInto<::http::request::Request<Vec<u8>>> for HttpRequest {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct HttpResponse {
     pub body: Vec<u8>,
     pub headers: HeaderFields,

--- a/sxg_rs/src/http_parser/cache_control.rs
+++ b/sxg_rs/src/http_parser/cache_control.rs
@@ -25,7 +25,7 @@ use nom::{
 use std::time::Duration;
 
 // https://datatracker.ietf.org/doc/html/rfc7234#section-5.2
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Directive {
     SMaxAge(Duration),
     MaxAge(Duration),

--- a/sxg_rs/src/http_parser/link.rs
+++ b/sxg_rs/src/http_parser/link.rs
@@ -27,7 +27,7 @@ use std::borrow::Cow;
 // from https://datatracker.ietf.org/doc/html/rfc8288#section-3.
 // Parameters with alternate character encodings (via RFC8187) are not
 // supported.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Link<'a> {
     pub uri: String,
     pub params: Vec<(Cow<'a, str>, Option<String>)>,

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -57,7 +57,7 @@ pub struct SxgWorker {
     certificates: VecDeque<CertificateChain>,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", tag = "kind")]
 pub enum PresetContent {
     Direct(HttpResponse),


### PR DESCRIPTION
Add `#[derive(Eq)]` for some types. If a type `T` derives `PartialEq` and all of its members implement `Eq`, then `T` can always implement `Eq`.

This is a new Rust linter rule [derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) added by Rust [1.63](https://github.com/rust-lang/rust-clippy/blob/84fb7e039565ac87f504af235940a568b90e7223/CHANGELOG.md#rust-163).