### PR TITLE
http_server: Flags for paths. Stream large bodies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,9 +1654,11 @@ name = "http_server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "clap 3.2.17",
  "fs2",
+ "futures",
  "http",
  "hyper",
  "hyper-reverse-proxy",

--- a/http_server/Cargo.toml
+++ b/http_server/Cargo.toml
@@ -25,14 +25,18 @@ anyhow = "1.0.62"
 async-trait = "0.1.57"
 clap = { version = "3.2.17", features = ["derive"] }
 fs2 = "0.4.3"
+futures = "0.3.23"
 http = "0.2.8"
 hyper-reverse-proxy = { git = "https://github.com/felipenoris/hyper-reverse-proxy", rev = "96a398de8522fac07a5e15bd0699f6cd7fa84bce" }
 hyper-rustls = "0.23.0"
 hyper-tls = "0.5.0"
 hyper-trust-dns = { version = "0.4.2", default-features = false, features = ["rustls-webpki", "rustls-http1", "rustls-tls-12"] }
-hyper = { version = "0.14.20", features = ["http1", "http2", "server", "tcp"] }
+hyper = { version = "0.14.20", features = ["http1", "http2", "server", "stream", "tcp"] }
 lazy_static = "1.4.0"
 # TODO: Determine if I can remove strip_id_headers because it's default.
 sxg_rs = { path = "../sxg_rs", features = ["strip_id_headers", "rust_signer"] }
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
 url = "2.2.2"
+
+[dev-dependencies]
+assert_matches = "1.5.0"

--- a/http_server/src/main.rs
+++ b/http_server/src/main.rs
@@ -187,8 +187,6 @@ struct SelfFetcher {
 #[async_trait]
 impl Fetcher for SelfFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
-        // TODO: Don't compute header-integrity for resources that are too
-        // large (see https://twifkak.com/link_tag.large.html).
         let response: Response<Body> = handle(self.client_ip, request).await?;
         match resp_to_vec_body(response).await? {
             Payload::InMemory(payload) => payload.try_into(),
@@ -303,7 +301,6 @@ enum HandleAction {
 // We can't work around this because http::header::HeaderMap panics with
 // InvalidHeaderName when given ":authority" as a key.
 async fn handle_impl(client_ip: IpAddr, req: HttpRequest) -> Result<HandleAction> {
-    // TODO: If over 8MB or MICE fails midstream, send the consumed portion and stream the rest.
     // TODO: Additional work necessary for ACME support?
     let fallback_url: String;
     let sxg_payload;

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -73,7 +73,7 @@ pub enum PresetContent {
 // <1h, an SXG would be instantly invalid; this would be confusing.)
 const BACKDATING: Duration = Duration::from_secs(60 * 60);
 
-pub(crate) const MAX_PAYLOAD_SIZE: usize = 8_000_000;
+pub const MAX_PAYLOAD_SIZE: usize = 8_000_000;
 
 impl SxgWorker {
     pub fn new(config_yaml: &str) -> Result<Self> {

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -72,7 +72,7 @@ pub fn process_html(input: HttpResponse, option: ProcessHtmlOption) -> HttpRespo
             ContentType::Other => return input,
         };
     } else {
-        // Doesn't process HTML because content-type header does not exsist.
+        // Doesn't process HTML because content-type header does not exist.
         return input;
     }
     let input_body = match String::from_utf8(input.body) {


### PR DESCRIPTION
- Add flags for the locations of config.yaml, cert.pem, and issuer.pem.
- Make Args a lazy_static! so it doesn't need to be copied and passed around.
- Stream response bodies >8MB rather than buffering them into memory.

Addresses #250.