### PR TITLE
Reduce clones of response body.

### DIFF
--- a/http_server/src/main.rs
+++ b/http_server/src/main.rs
@@ -386,8 +386,7 @@ async fn proxy_unsigned(client_ip: IpAddr, req: HttpRequest) -> Result<Response<
     Ok(match resp_to_vec_body(payload).await? {
         Payload::InMemory(payload) => {
             let payload: HttpResponse = payload.try_into()?;
-            let payload =
-                WORKER.process_html(payload.into(), ProcessHtmlOption { is_sxg: false });
+            let payload = WORKER.process_html(payload.into(), ProcessHtmlOption { is_sxg: false });
             let payload = Arc::try_unwrap(payload).unwrap_or_else(|p| (*p).clone());
             let payload: Response<Vec<u8>> = payload.try_into()?;
             payload.map(Body::from)

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -46,6 +46,7 @@ use http_cache::HttpCache;
 use runtime::Runtime;
 use serde::Serialize;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
@@ -118,9 +119,9 @@ impl SxgWorker {
     }
     pub fn process_html(
         &self,
-        input: HttpResponse,
+        input: Arc<HttpResponse>,
         option: process_html::ProcessHtmlOption,
-    ) -> HttpResponse {
+    ) -> Arc<HttpResponse> {
         process_html::process_html(input, option)
     }
     pub async fn create_signed_exchange<C: HttpCache>(

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -154,7 +154,7 @@ pub fn process_html(input: Arc<HttpResponse>, option: ProcessHtmlOption) -> Arc<
         }),
     ];
     let output = match lol_html::rewrite_str(
-        &input_body,
+        input_body,
         lol_html::Settings {
             element_content_handlers,
             ..lol_html::Settings::default()

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -223,9 +223,11 @@ mod tests {
                 status: 200,
                 headers: vec![("content-type".to_string(), content_type.to_string())],
                 body: input_body.to_string().into_bytes(),
-            },
+            }
+            .into(),
             ProcessHtmlOption { is_sxg },
         );
+        let output = Arc::try_unwrap(output).unwrap_or_else(|o| (*o).clone());
         String::from_utf8(output.body).unwrap()
     }
     #[test]
@@ -282,21 +284,24 @@ mod tests {
             <script data-issxg-var>window.isSXG=true</script>",
         );
         // HTTP content-length header is updated
+        let output = process_html(
+            HttpResponse {
+                status: 200,
+                headers: vec![
+                    (
+                        "content-type".to_string(),
+                        "text/html;charset=utf-8".to_string(),
+                    ),
+                    ("content-length".to_string(), "32".to_string()),
+                ],
+                body: "<script data-issxg-var></script>".to_string().into_bytes(),
+            }
+            .into(),
+            ProcessHtmlOption { is_sxg: true },
+        );
+        let output = Arc::try_unwrap(output).unwrap_or_else(|o| (*o).clone());
         assert_eq!(
-            process_html(
-                HttpResponse {
-                    status: 200,
-                    headers: vec![
-                        (
-                            "content-type".to_string(),
-                            "text/html;charset=utf-8".to_string()
-                        ),
-                        ("content-length".to_string(), "32".to_string()),
-                    ],
-                    body: "<script data-issxg-var></script>".to_string().into_bytes(),
-                },
-                ProcessHtmlOption { is_sxg: true },
-            ),
+            output,
             HttpResponse {
                 status: 200,
                 headers: vec![

--- a/sxg_rs/src/process_html.rs
+++ b/sxg_rs/src/process_html.rs
@@ -167,7 +167,8 @@ pub fn process_html(input: Arc<HttpResponse>, option: ProcessHtmlOption) -> Arc<
                 headers: input.headers,
                 status: input.status,
                 body: input_body.into(),
-            }.into();
+            }
+            .into();
         }
     };
     if !known_utf8 {
@@ -175,7 +176,8 @@ pub fn process_html(input: Arc<HttpResponse>, option: ProcessHtmlOption) -> Arc<
             headers: input.headers,
             status: input.status,
             body: input_body.into(),
-        }.into();
+        }
+        .into();
     }
     let mut output_headers = input.headers;
     if !link_headers.is_empty() {
@@ -191,7 +193,8 @@ pub fn process_html(input: Arc<HttpResponse>, option: ProcessHtmlOption) -> Arc<
         body: output_body,
         headers: output_headers,
         status: input.status,
-    }.into()
+    }
+    .into()
 }
 
 #[cfg(test)]

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -149,7 +149,8 @@ impl WasmWorker {
         future_to_promise(async move {
             let input: HttpResponse = input.into_serde().map_err(to_js_error)?;
             let option: ProcessHtmlOption = option.into_serde().map_err(to_js_error)?;
-            let output = worker.read().await.process_html(input, option);
+            let output = worker.read().await.process_html(input.into(), option);
+            let output = Arc::try_unwrap(output).unwrap_or_else(|o| (*o).clone());
             JsValue::from_serde(&output).map_err(to_js_error)
         })
     }


### PR DESCRIPTION
Change process_html to take and return an Arc<HttpResponse> instead of an
HttpResponse. This allows it to either return the original or the transformed
payload, while the caller keeps a reference to the original. Now, the response
body should only be copied if transformation occurs (the document has a
`<meta charset=utf-8>`).

This copy is necessary in the event that create_signed_exchange errors. In that
case, http_server will process_html(is_sxg=false) on the original.

Alternatively, we could change process_html to output information to allow
process_html(is_sxg=false) to be applied on top of process_html(is_sxg=true).
For instance, when handling template[data-sxg-only] if is_sxg=true, it could
insert comments before and after the content. If is_sxg=false, it could look
for those comments and reinsert the template tag. Left a TODO for that.

Another alternative could be to predict whether signing would fail before
transforming. This would be imperfect -- e.g. transformation may increase or
decrease the size of the payload across the 8MB boundary -- but maybe a close
enough approximation. Whether this is an optimization or a pessimization
(effectively signing twice) depends on how often signing will fail (e.g. due to
cache-control headers).