### PR TITLE
http_server: Add header-integrity cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "hyper-tls",
  "hyper-trust-dns",
  "lazy_static",
+ "lru",
  "sxg_rs",
  "tokio",
  "url",
@@ -2031,6 +2032,15 @@ dependencies = [
  "safemem",
  "selectors",
  "thiserror",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]

--- a/http_server/Cargo.toml
+++ b/http_server/Cargo.toml
@@ -33,9 +33,10 @@ hyper-tls = "0.5.0"
 hyper-trust-dns = { version = "0.4.2", default-features = false, features = ["rustls-webpki", "rustls-http1", "rustls-tls-12"] }
 hyper = { version = "0.14.20", features = ["http1", "http2", "server", "stream", "tcp"] }
 lazy_static = "1.4.0"
+lru = "0.7.8"
 # TODO: Determine if I can remove strip_id_headers because it's default.
 sxg_rs = { path = "../sxg_rs", features = ["strip_id_headers", "rust_signer"] }
-tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros", "sync"] }
 url = "2.2.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Add an in-memory LRU cache for header-integrity values, to reduce the number of
backend fetches for subresources.

Addresses #250.