### PR TITLE
Remove global static worker in Fastly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,7 +1237,6 @@ dependencies = [
  "http",
  "log",
  "log-fastly",
- "once_cell",
  "pem",
  "serde",
  "serde_yaml",

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -30,7 +30,6 @@ fastly = "^0.8.7"
 http = "0.2.8"
 log = "0.4.17"
 log-fastly = "0.8.7"
-once_cell = "1.13.1"
 pem = "1.1.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_yaml = "0.9.10"

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -21,16 +21,15 @@ use fastly::{
     Request, Response,
 };
 use fetcher::FastlyFetcher;
-use once_cell::sync::Lazy;
 use std::convert::TryInto;
 use sxg_rs::{
     crypto::CertificateChain,
     headers::{AcceptFilter, Headers},
     http::HeaderFields,
-    PresetContent,
+    PresetContent, SxgWorker,
 };
 
-pub static WORKER: Lazy<::sxg_rs::SxgWorker> = Lazy::new(|| {
+fn create_worker() -> SxgWorker {
     let mut worker = ::sxg_rs::SxgWorker::new(include_str!("../config.yaml")).unwrap();
     let certificate = CertificateChain::from_pem_files(&[
         include_str!("../../credentials/cert.pem"),
@@ -39,7 +38,7 @@ pub static WORKER: Lazy<::sxg_rs::SxgWorker> = Lazy::new(|| {
     .unwrap();
     worker.add_certificate(certificate);
     worker
-});
+}
 
 fn binary_response(status_code: StatusCode, content_type: Mime, body: &[u8]) -> Response {
     let mut response = Response::new();
@@ -53,7 +52,11 @@ fn text_response(body: &str) -> Response {
     binary_response(StatusCode::OK, fastly::mime::TEXT_PLAIN, body.as_bytes())
 }
 
-fn get_req_header_fields(req: &Request, accept_filter: AcceptFilter) -> Result<HeaderFields> {
+async fn get_req_header_fields(
+    worker: &SxgWorker,
+    req: &Request,
+    accept_filter: AcceptFilter,
+) -> Result<HeaderFields> {
     let mut fields: Vec<(String, String)> = vec![];
     for name in req.get_header_names() {
         for value in req.get_header_all(name) {
@@ -63,10 +66,10 @@ fn get_req_header_fields(req: &Request, accept_filter: AcceptFilter) -> Result<H
             fields.push((name.as_str().to_string(), value.to_string()))
         }
     }
-    WORKER.transform_request_headers(fields, accept_filter)
+    worker.transform_request_headers(fields, accept_filter)
 }
 
-fn get_rsp_header_fields(rsp: &Response) -> Result<Headers> {
+async fn get_rsp_header_fields(worker: &SxgWorker, rsp: &Response) -> Result<Headers> {
     let mut fields: Vec<(String, String)> = vec![];
     for name in rsp.get_header_names() {
         for value in rsp.get_header_all(name) {
@@ -76,7 +79,7 @@ fn get_rsp_header_fields(rsp: &Response) -> Result<Headers> {
             fields.push((name.as_str().to_string(), value.to_string()))
         }
     }
-    WORKER.transform_payload_headers(fields)
+    worker.transform_payload_headers(fields)
 }
 
 pub fn sxg_rs_response_to_fastly_response(
@@ -96,17 +99,20 @@ fn fetch_from_html_server(url: &Url, req_headers: Vec<(String, String)>) -> Resu
         .map_err(|err| Error::msg(format!(r#"Fetching "{}" leads to error "{}""#, url, err)))
 }
 
-async fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<Response> {
-    let payload_headers = get_rsp_header_fields(&payload)?;
+async fn generate_sxg_response(
+    worker: &SxgWorker,
+    fallback_url: &Url,
+    payload: Response,
+) -> Result<Response> {
+    let payload_headers = get_rsp_header_fields(worker, &payload).await?;
     let payload_body = payload.into_body_bytes();
     let cert_origin = fallback_url.origin().ascii_serialization();
     let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
-        sxg_signer: Box::new(WORKER.create_rust_signer()?),
         fetcher: Box::new(FastlyFetcher::new("subresources")),
         ..Default::default()
     };
-    let sxg = WORKER.create_signed_exchange(
+    let sxg = worker.create_signed_exchange(
         &runtime,
         sxg_rs::CreateSignedExchangeParams {
             payload_body: &payload_body,
@@ -125,16 +131,15 @@ async fn generate_sxg_response(fallback_url: &Url, payload: Response) -> Result<
     sxg_rs_response_to_fastly_response(sxg)
 }
 
-async fn handle_request(req: Request) -> Result<Response> {
+async fn handle_request(worker: &SxgWorker, req: Request) -> Result<Response> {
     let runtime = sxg_rs::runtime::Runtime {
         now: std::time::SystemTime::now(),
-        sxg_signer: Box::new(WORKER.create_rust_signer()?),
         fetcher: Box::new(FastlyFetcher::new("OCSP server")),
         ..Default::default()
     };
     let fallback_url: Url;
     let sxg_payload;
-    let preset_content = WORKER
+    let preset_content = worker
         .serve_preset_content(&runtime, req.get_url_str())
         .await;
     match preset_content {
@@ -144,15 +149,15 @@ async fn handle_request(req: Request) -> Result<Response> {
         Some(PresetContent::ToBeSigned { url, payload, .. }) => {
             fallback_url = Url::parse(&url).map_err(Error::new)?;
             sxg_payload = sxg_rs_response_to_fastly_response(payload)?;
-            get_req_header_fields(&req, AcceptFilter::AcceptsSxg)?;
+            get_req_header_fields(worker, &req, AcceptFilter::AcceptsSxg).await?;
         }
         None => {
-            fallback_url = WORKER.get_fallback_url(req.get_url())?;
-            let req_headers = get_req_header_fields(&req, AcceptFilter::PrefersSxg)?;
+            fallback_url = worker.get_fallback_url(req.get_url())?;
+            let req_headers = get_req_header_fields(worker, &req, AcceptFilter::PrefersSxg).await?;
             sxg_payload = fetch_from_html_server(&fallback_url, req_headers)?;
         }
     };
-    generate_sxg_response(&fallback_url, sxg_payload).await
+    generate_sxg_response(worker, &fallback_url, sxg_payload).await
 }
 
 #[fastly::main]
@@ -161,7 +166,8 @@ fn main(req: Request) -> Result<Response, std::convert::Infallible> {
         .build()
         .unwrap()
         .block_on(async {
-            let response = handle_request(req).await.unwrap_or_else(|msg| {
+            let worker = create_worker();
+            let response = handle_request(&worker, req).await.unwrap_or_else(|msg| {
                 text_response(&format!("A message is gracefully thrown.\n{:?}", msg))
             });
             Ok(response)
@@ -173,6 +179,6 @@ mod tests {
     use super::*;
     #[test]
     fn it_works() {
-        WORKER.create_rust_signer().unwrap();
+        create_worker().create_rust_signer().unwrap();
     }
 }


### PR DESCRIPTION
The worker is now created at the beginning of `main` function, and is passed as a function argument.

This allows us to add more complex operations when initializing `SxgWorker`, regardless the constraints given by global `Lazy` variable. 