### PR TITLE
Ensure test SXG uses HTML domain

### DIFF
--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -277,6 +277,7 @@ impl SxgWorker {
                     let mut fallback_url = req_url;
                     fallback_url
                         .set_path(&fallback_url.path().replace("test.sxg", "fallback.html"));
+                    let fallback_url = self.get_fallback_url(&fallback_url).ok()?;
                     Some(PresetContent::ToBeSigned {
                         url: fallback_url.to_string(),
                         payload: HttpResponse {


### PR DESCRIPTION
Fix a bug that in off-path mode, the fallback URL of `test.sxg` was incorrectly using worker's domain name.

Now we use `get_fallback_url()` to ensure the fallback URL to be under `config.html_host`.