### PR TITLE
Get certificate origin from SXG outer URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "serde_yaml",
  "sxg_rs",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -4115,13 +4116,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding 2.1.0",
  "serde",
 ]

--- a/fastly_compute/Cargo.toml
+++ b/fastly_compute/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_yaml = "0.9.10"
 sxg_rs = { path = "../sxg_rs", features = ["rust_signer"] }
 tokio = { version = "1.20.1", features = ["rt"] }
+url = "2.3.0"
 
 [features]
 # Unsupported, but necessary to make `cargo some-cmd --all-features` happy.

--- a/http_server/src/main.rs
+++ b/http_server/src/main.rs
@@ -366,7 +366,10 @@ async fn handle_impl(client_ip: IpAddr, req: HttpRequest) -> Result<HandleAction
         None => {
             // TODO: Reduce the amount of conversion needed between request/response/header types.
             let backend_url = url::Url::parse(&ARGS.backend)?.join(&req.url)?;
-            fallback_url = worker.get_fallback_url(&backend_url)?.into();
+            fallback_url = worker
+                .get_fallback_url_and_cert_origin(&backend_url)?
+                .0
+                .to_string();
             let req_headers =
                 worker.transform_request_headers(req.headers, AcceptFilter::PrefersSxg)?;
             let mut request = Request::builder()


### PR DESCRIPTION
* Implement `get_fallback_url_and_cert_origin` in Rust.
* Fix a bug that Fastly worker has been incorrectly using the origin of `fallback_url` as certificate origin.