### PR TITLE
Integrate ACME challenge with Fastly edge dictionary

### DIFF
--- a/fastly_compute/README.md
+++ b/fastly_compute/README.md
@@ -82,7 +82,7 @@ but may reuse them for up to 7 days. To ensure they expire sooner, set
    - It is not recommended to directly modify the generated `fastly.toml`, because your changes will be
      overwriten when you run `cargo run -p tools -- gen-config` again.
 
-   1. Modify the WASM service in [Fastly](https://manage.fastly.com/).
+1. Modify the WASM service in [Fastly](https://manage.fastly.com/).
 
    <!--TODO: Use CLI to add domains and backends-->
    1. Add a domain to the service.

--- a/sxg_rs/src/acme/state_machine.rs
+++ b/sxg_rs/src/acme/state_machine.rs
@@ -22,7 +22,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime};
 
-const ACME_STORAGE_KEY: &str = "ACME";
+pub const ACME_STORAGE_KEY: &str = "ACME";
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AcmeStorageData {
@@ -237,6 +237,38 @@ pub async fn get_challenge_token_and_answer(runtime: &Runtime) -> Result<Option<
         )))
     } else {
         Ok(None)
+    }
+}
+
+pub fn create_from_challenge(
+    challenge_token: impl ToString,
+    challenge_answer: impl ToString,
+) -> AcmeStorageData {
+    AcmeStorageData {
+        certificates: vec![],
+        task: Some(Task {
+            order: OngoingOrder {
+                challenge_token: challenge_token.to_string(),
+                challenge_answer: challenge_answer.to_string(),
+                authorization_url: String::new(),
+                certificate_url: None,
+                challenge_url: String::new(),
+                finalize_url: String::new(),
+                order_url: String::new(),
+            },
+            schedule: Schedule {
+                updated_at: SystemTime::UNIX_EPOCH,
+                wait_time: Duration::ZERO,
+                next_step: TaskStep::RequestChallengeValidation,
+            },
+        }),
+    }
+}
+
+pub fn create_from_certificate(certificate_pem: impl ToString) -> AcmeStorageData {
+    AcmeStorageData {
+        certificates: vec![certificate_pem.to_string()],
+        task: None,
     }
 }
 

--- a/tools/src/commands/apply_acme_cert.rs
+++ b/tools/src/commands/apply_acme_cert.rs
@@ -107,7 +107,7 @@ pub async fn main(opts: Opts) -> Result<()> {
         );
         let actual_response = sxg_rs::fetcher::get(runtime.fetcher.as_ref(), &url).await?;
         if let Ok(actual_response) = String::from_utf8(actual_response) {
-            if actual_response.trim() == &challenge_answer {
+            if actual_response.trim() == challenge_answer {
                 println!("ACME challenge answer succesfully detected.");
                 break;
             }

--- a/tools/src/commands/apply_acme_cert.rs
+++ b/tools/src/commands/apply_acme_cert.rs
@@ -28,9 +28,13 @@ pub struct Opts {
     port: Option<u16>,
     #[clap(long)]
     artifact: String,
+    /// Puts challenge answer and certificate to Fastly edge dictionary.
+    #[clap(long)]
+    use_fastly_dictionary: bool,
 }
 
-fn start_warp_server(port: u16, answer: String) -> tokio::sync::oneshot::Sender<()> {
+fn start_warp_server(port: u16, answer: impl ToString) -> tokio::sync::oneshot::Sender<()> {
+    let answer = answer.to_string();
     let (tx, rx) = tokio::sync::oneshot::channel();
     let routes =
         warp::path!(".well-known" / "acme-challenge" / String).map(move |_name| answer.to_string());
@@ -40,10 +44,6 @@ fn start_warp_server(port: u16, answer: String) -> tokio::sync::oneshot::Sender<
         });
     tokio::spawn(server);
     tx
-}
-
-fn wait_enter_key() {
-    std::io::stdin().read_line(&mut String::new()).unwrap();
 }
 
 pub async fn main(opts: Opts) -> Result<()> {
@@ -63,23 +63,59 @@ pub async fn main(opts: Opts) -> Result<()> {
         }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     };
+
+    let challenge_url = format!(
+        "http://{}/.well-known/acme-challenge/{}",
+        acme_account.domain, challenge_token
+    );
     let graceful_shutdown = if let Some(port) = opts.port {
-        Some(start_warp_server(port, challenge_answer))
+        println!("Serving ACME challenge answer on local port {}, assuming that this port is binding to http://{}/", port, acme_account.domain);
+        Some(start_warp_server(port, &challenge_answer))
+    } else if opts.use_fastly_dictionary {
+        println!("Writing ACME challenge answer to Fastly edige dictionary.");
+        let acme_state =
+            sxg_rs::acme::state_machine::create_from_challenge(&challenge_token, &challenge_answer);
+        super::gen_config::fastly::update_dictionary_item(
+            artifact.fastly_service_id.as_ref().unwrap(),
+            artifact.fastly_dictionary_id.as_ref().unwrap(),
+            sxg_rs::acme::state_machine::ACME_STORAGE_KEY,
+            &serde_json::to_string(&acme_state)?,
+        )?;
+        None
     } else {
         println!(
             "\
             Please create a file in your HTTP server to serve the following URL.\n\
             URL:\n\
-            http://{}/.well-known/acme-challenge/{}\n\
+            {}\n\
             Plain-text content:\n\
             {}\n\
-            Press Enter key after your HTTP server is ready.\
             ",
-            acme_account.domain, challenge_token, challenge_answer
+            challenge_url, challenge_answer
         );
-        wait_enter_key();
         None
     };
+
+    println!(
+        "Waiting for the propagation of ACME challenge answer; checking every 10 seconds from {}.",
+        challenge_url
+    );
+    loop {
+        let url = format!(
+            "http://{}/.well-known/acme-challenge/{}",
+            acme_account.domain, challenge_token
+        );
+        let actual_response = sxg_rs::fetcher::get(runtime.fetcher.as_ref(), &url).await?;
+        if let Ok(actual_response) = String::from_utf8(actual_response) {
+            if actual_response.trim() == &challenge_answer {
+                println!("ACME challenge answer succesfully detected.");
+                break;
+            }
+        }
+        print!(".");
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+    }
+
     let certificate_pem = loop {
         runtime.now = std::time::SystemTime::now();
         update_acme_state_machine(&runtime, &acme_account).await?;
@@ -89,9 +125,20 @@ pub async fn main(opts: Opts) -> Result<()> {
         }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     };
+    if opts.use_fastly_dictionary {
+        println!("Uploading certificates to Fastly edge dicionary.");
+        let acme_state = sxg_rs::acme::state_machine::create_from_certificate(certificate_pem);
+        super::gen_config::fastly::update_dictionary_item(
+            artifact.fastly_service_id.as_ref().unwrap(),
+            artifact.fastly_dictionary_id.as_ref().unwrap(),
+            sxg_rs::acme::state_machine::ACME_STORAGE_KEY,
+            &serde_json::to_string(&acme_state)?,
+        )?;
+    } else {
+        println!("{}", certificate_pem);
+    }
     if let Some(tx) = graceful_shutdown {
         let _ = tx.send(());
     }
-    println!("{}", certificate_pem);
     Ok(())
 }

--- a/tools/src/commands/gen_config/fastly.rs
+++ b/tools/src/commands/gen_config/fastly.rs
@@ -136,6 +136,28 @@ pub fn create_dictionary_item(
     Ok(())
 }
 
+pub fn update_dictionary_item(
+    service_id: &str,
+    dictionary_id: &str,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    execute_and_parse_stdout(
+        Command::new("fastly")
+            .arg("dictionary-item")
+            .arg("update")
+            .arg("--service-id")
+            .arg(service_id)
+            .arg("--dictionary-id")
+            .arg(dictionary_id)
+            .arg("--key")
+            .arg(key)
+            .arg("--value")
+            .arg(value),
+    )?;
+    Ok(())
+}
+
 pub fn main(
     use_ci_mode: bool,
     sxg_input: &SxgConfig,

--- a/tools/src/commands/gen_config/mod.rs
+++ b/tools/src/commands/gen_config/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod cloudflare;
-mod fastly;
+pub mod fastly;
 mod http_server;
 
 use crate::linux_commands::generate_private_key_pem;


### PR DESCRIPTION
Overall procedure of ACME with Fastly

1. Deploy Fastly worker with no ACME data.
2. Run `apply_acme_cert` locally, which
    1. connects to ACME server and creates challenge URL and challenge answer;
    2. puts ACME challenge data to Fastly online dictionary;
    3. waits Fastly worker to load ACME challenge data from online dictionary;
    4. notifies ACME server that Fastly worker is ready for challenge;
    5. gets certificate from ACME server, and puts it to Fastly online dictionary.