### PR TITLE
Update wasm-bindgen to 0.2.83

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,6 +3178,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfc62771e7b829b517cb213419236475f434fb480eddd76112ae182d274434a"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3496,7 @@ dependencies = [
  "p256",
  "pem",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_yaml",
  "sha1",
@@ -4236,8 +4248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,9 +4231,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -4243,9 +4243,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -4270,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4293,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"

--- a/cloudflare_worker/Cargo.toml
+++ b/cloudflare_worker/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 console_error_panic_hook = "0.1.7"
 sxg_rs = { path = "../sxg_rs", features = ["wasm"] }
-wasm-bindgen = "0.2.82"
+wasm-bindgen = "0.2.83"
 
 [profile.release]
 opt-level = 3

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -46,13 +46,14 @@ once_cell = "1.13.1"
 pem = "1.1.0"
 p256 = { version = "0.11.1", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.144", features = ["derive"] }
+serde-wasm-bindgen = "0.4.3"
 serde_json = "1.0.85"
 serde_yaml = "0.9.10"
 sha1 = "0.10.1"
 sha2 = "0.10.2"
 tokio = { version = "1.20.1", features = ["macros", "parking_lot", "sync", "time"] }
 url = "2.2.2"
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = "0.2.83"
 wasm-bindgen-futures = "0.4.32"
 web-sys = { version = "0.3.59", features = ["console"] }
 x509-parser = "0.14.0"

--- a/sxg_rs/Cargo.toml
+++ b/sxg_rs/Cargo.toml
@@ -52,7 +52,7 @@ sha1 = "0.10.1"
 sha2 = "0.10.2"
 tokio = { version = "1.20.1", features = ["macros", "parking_lot", "sync", "time"] }
 url = "2.2.2"
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.32"
 web-sys = { version = "0.3.59", features = ["console"] }
 x509-parser = "0.14.0"

--- a/sxg_rs/src/fetcher/js_fetcher.rs
+++ b/sxg_rs/src/fetcher/js_fetcher.rs
@@ -41,12 +41,11 @@ impl JsFetcher {
 #[async_trait(?Send)]
 impl Fetcher for JsFetcher {
     async fn fetch(&self, request: HttpRequest) -> Result<HttpResponse> {
-        let request = JsValue::from_serde(&request)
-            .map_err(|e| Error::new(e).context("Failed to parse request."))?;
+        let request = serde_wasm_bindgen::to_value(&request)
+            .map_err(|e| Error::msg(e.to_string()).context("Failed to parse request."))?;
         let response = await_js_promise(self.0.call1(&JsValue::NULL, &request)).await?;
-        let response: HttpResponse = response
-            .into_serde()
-            .map_err(|e| Error::new(e).context("Failed to serialize response."))?;
+        let response: HttpResponse = serde_wasm_bindgen::from_value(response)
+            .map_err(|e| Error::msg(e.to_string()).context("Failed to serialize response."))?;
         Ok(response)
     }
 }

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -121,7 +121,8 @@ impl WasmWorker {
         let worker = self.0.clone();
         future_to_promise(async move {
             let fields = serde_wasm_bindgen::from_value(requestor_headers).map_err(to_js_error)?;
-            let accept_filter: AcceptFilter = serde_wasm_bindgen::from_value(accept_filter).map_err(to_js_error)?;
+            let accept_filter: AcceptFilter =
+                serde_wasm_bindgen::from_value(accept_filter).map_err(to_js_error)?;
             let fields = worker
                 .read()
                 .await
@@ -134,7 +135,8 @@ impl WasmWorker {
     pub fn validate_payload_headers(&self, fields: JsValue) -> JsPromise {
         let worker = self.0.clone();
         future_to_promise(async move {
-            let fields: Vec<(String, String)> = serde_wasm_bindgen::from_value(fields).map_err(to_js_error)?;
+            let fields: Vec<(String, String)> =
+                serde_wasm_bindgen::from_value(fields).map_err(to_js_error)?;
             worker
                 .read()
                 .await
@@ -148,7 +150,8 @@ impl WasmWorker {
         let worker = self.0.clone();
         future_to_promise(async move {
             let input: HttpResponse = serde_wasm_bindgen::from_value(input).map_err(to_js_error)?;
-            let option: ProcessHtmlOption = serde_wasm_bindgen::from_value(option).map_err(to_js_error)?;
+            let option: ProcessHtmlOption =
+                serde_wasm_bindgen::from_value(option).map_err(to_js_error)?;
             let output = worker.read().await.process_html(input.into(), option);
             let output = Arc::try_unwrap(output).unwrap_or_else(|o| (*o).clone());
             serde_wasm_bindgen::to_value(&output).map_err(to_js_error)
@@ -163,9 +166,8 @@ impl WasmWorker {
         let worker = self.0.clone();
         future_to_promise(async move {
             let runtime = Runtime::try_from(js_runtime).map_err(to_js_error)?;
-            let payload_headers: Vec<(String, String)> = serde_wasm_bindgen::from_value(options
-                .payload_headers())
-                .map_err(to_js_error)?;
+            let payload_headers: Vec<(String, String)> =
+                serde_wasm_bindgen::from_value(options.payload_headers()).map_err(to_js_error)?;
             let worker = worker.read().await;
             let payload_headers = worker
                 .transform_payload_headers(payload_headers)


### PR DESCRIPTION
* Update `wasm-bindgen` from `0.2.82` to `0.2.83`.
* Replace `wasm_bindgen::JsValue::from_serde` by `serde_wasm_bindgen::to_value`, and replace `wasm_bindgen::JsValue::into_serde` by `serde_wasm_bindgen::from_value`, because `JsValue::from_serde` and `JsValue::into_serde` is now [deprecated](https://github.com/rustwasm/wasm-bindgen/pull/3031).