### PR TITLE
Update lru to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.8"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+checksum = "936d98d2ddd79c18641c6709e7bb09981449694e402d1a0f0f657ea8d61f4a51"
 dependencies = [
  "hashbrown",
 ]

--- a/http_server/Cargo.toml
+++ b/http_server/Cargo.toml
@@ -33,7 +33,7 @@ hyper-tls = "0.5.0"
 hyper-trust-dns = { version = "0.4.2", default-features = false, features = ["rustls-webpki", "rustls-http1", "rustls-tls-12"] }
 hyper = { version = "0.14.20", features = ["http1", "http2", "server", "stream", "tcp"] }
 lazy_static = "1.4.0"
-lru = "0.7.8"
+lru = "0.8.0"
 rand = "0.8.5"
 serde_yaml = "0.9.10"
 # TODO: Determine if I can remove strip_id_headers because it's default.

--- a/http_server/src/main.rs
+++ b/http_server/src/main.rs
@@ -97,7 +97,7 @@ struct Args {
 
     /// Maximum number of entries in the header integrity cache. Each entry will be about 1KB.
     #[clap(long, default_value = "2000")]
-    header_integrity_cache_size: usize,
+    header_integrity_cache_size: std::num::NonZeroUsize,
 }
 
 type HttpsClient = hyper::Client<


### PR DESCRIPTION
* Update `lru` to `0.8.0`.
* Fix the [breaking change](https://github.com/jeromefroe/lru-rs/blob/e2e887e85c339404dcb6e297d023f47294361124/CHANGELOG.md#v080---2022-09-11) that LRU capacity is now a `NonZeroUsize`.