### PR TITLE
Signature parsing improvements

### DIFF
--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -31,7 +31,7 @@ pub mod runtime;
 pub mod serde_helpers;
 pub mod signature;
 pub mod storage;
-mod structured_header;
+pub mod structured_header;
 pub mod sxg;
 pub mod utils;
 #[cfg(feature = "wasm")]

--- a/sxg_rs/src/signature/mod.rs
+++ b/sxg_rs/src/signature/mod.rs
@@ -141,8 +141,8 @@ impl<'a> Signature<'a> {
             "validity-url".into(),
             Some(ShItem::String(self.validity_url.into())),
         ));
-        param.push(("date".into(), Some(ShItem::Integer(self.date.into()))));
-        param.push(("expires".into(), Some(ShItem::Integer(self.expires.into()))));
+        param.push(("date".into(), Some(ShItem::Integer(self.date))));
+        param.push(("expires".into(), Some(ShItem::Integer(self.expires))));
         list.push(param);
         format!("{}", list).into_bytes()
     }

--- a/sxg_rs/src/structured_header/item.rs
+++ b/sxg_rs/src/structured_header/item.rs
@@ -15,7 +15,7 @@
 use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ShItem<'a> {
     ByteSequence(Cow<'a, [u8]>),
     Integer(i64),

--- a/sxg_rs/src/structured_header/item.rs
+++ b/sxg_rs/src/structured_header/item.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ShItem<'a> {
-    ByteSequence(&'a [u8]),
-    Integer(u64),
-    String(&'a str),
+    ByteSequence(Cow<'a, [u8]>),
+    Integer(i64),
+    String(Cow<'a, str>),
 }
 
 // should be https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-10#section-4.1.5

--- a/sxg_rs/src/structured_header/parameterised_list.rs
+++ b/sxg_rs/src/structured_header/parameterised_list.rs
@@ -42,6 +42,12 @@ impl<'a> ShParamList<'a> {
     }
 }
 
+impl<'a> Default for ShParamList<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> Deref for ParamItem<'a> {
     type Target = Vec<(Cow<'a, str>, Option<ShItem<'a>>)>;
     fn deref(&self) -> &Self::Target {

--- a/sxg_rs/src/structured_header/parameterised_list.rs
+++ b/sxg_rs/src/structured_header/parameterised_list.rs
@@ -12,22 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 use super::ShItem;
 
+#[derive(Debug)]
 pub struct ParamItem<'a> {
-    primary_id: &'a str,
-    parameters: Vec<(&'a str, Option<ShItem<'a>>)>,
+    pub primary_id: Cow<'a, str>,
+    pub parameters: Vec<(Cow<'a, str>, Option<ShItem<'a>>)>,
 }
 
-pub struct ShParamList<'a>(Vec<ParamItem<'a>>);
+#[derive(Debug)]
+pub struct ShParamList<'a>(pub Vec<ParamItem<'a>>);
 
 impl<'a> ParamItem<'a> {
     pub fn new(primary_id: &'a str) -> Self {
         ParamItem {
-            primary_id,
+            primary_id: primary_id.into(),
             parameters: Vec::new(),
         }
     }
@@ -40,7 +43,7 @@ impl<'a> ShParamList<'a> {
 }
 
 impl<'a> Deref for ParamItem<'a> {
-    type Target = Vec<(&'a str, Option<ShItem<'a>>)>;
+    type Target = Vec<(Cow<'a, str>, Option<ShItem<'a>>)>;
     fn deref(&self) -> &Self::Target {
         &self.parameters
     }


### PR DESCRIPTION
- Make date/expires i64 to align with the range of strucutured header integers.
- Make ShItem and ParamItem store Cows instead of &strs, for use in generating new signatures.
- Make a few things pub and Debug.