### PR TITLE
Fix duplicate upstream via headers

### DIFF
--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -97,8 +97,6 @@ impl Headers {
             .filter_map(|(k, v)| {
                 let v = if forwarded_header_names.contains(&k) {
                     v
-                } else if k == "via" {
-                    format!("{}, {}", v, via)
                 } else {
                     return None;
                 };
@@ -497,6 +495,20 @@ mod tests {
                 .into_iter()
                 .collect::<HashMap<String, String>>(),
             header_fields(vec![("user-agent", USER_AGENT), ("via", "sxgrs")])
+        );
+    }
+    #[test]
+    fn upstream_via_header() {
+        assert_eq!(
+            headers(vec![
+                ("accept", "application/signed-exchange;v=b3"),
+                ("via", "nginx")
+            ])
+            .forward_to_origin_server(AcceptFilter::PrefersSxg, &BTreeSet::new())
+            .unwrap()
+            .into_iter()
+            .collect::<HashMap<String, String>>(),
+            header_fields(vec![("user-agent", USER_AGENT), ("via", "nginx, sxgrs")])
         );
     }
     #[test]


### PR DESCRIPTION
Fix the bug that output `via` header contains two copies of upstream `via` headers. The upstream `via` header has been included at [line 91](https://github.com/google/sxg-rs/blob/5f4cdb2ca0ac00b007459ab94fc24069aab37ea0/sxg_rs/src/headers.rs#L91).