### PR TITLE
Split content parsing and level validating

### DIFF
--- a/distributor/src/main.rs
+++ b/distributor/src/main.rs
@@ -44,7 +44,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 use sxg_rs::{
-    headers::{validate_accept_header, AcceptFilter::AcceptsSxg},
+    headers::{parse_accept_level, AcceptLevel::AcceptsSxg},
     http_parser::{link::Link, parse_content_type_header},
     sxg,
 };
@@ -169,7 +169,7 @@ fn accepts_sxg(headers: &HeaderMap) -> bool {
     header_is(headers, "accept", |value| {
         matches!(std::str::from_utf8(value),
                  Ok(value_str) if value_str == "application/cert-chain+cbor"
-                     || validate_accept_header(value_str, AcceptsSxg).is_ok())
+                     || parse_accept_level(value_str) >= AcceptsSxg)
     })
 }
 

--- a/fastly_compute/src/main.rs
+++ b/fastly_compute/src/main.rs
@@ -21,7 +21,7 @@ use fetcher::FastlyFetcher;
 use std::convert::TryInto;
 use sxg_rs::{
     crypto::CertificateChain,
-    headers::{AcceptFilter, Headers, VIA_SXGRS},
+    headers::{AcceptLevel, Headers, VIA_SXGRS},
     http::HeaderFields,
     PresetContent, SxgWorker,
 };
@@ -52,7 +52,7 @@ async fn create_worker() -> SxgWorker {
 async fn get_req_header_fields(
     worker: &SxgWorker,
     req: &Request,
-    accept_filter: AcceptFilter,
+    accept_filter: AcceptLevel,
 ) -> Result<HeaderFields> {
     let mut fields: Vec<(String, String)> = vec![];
     for name in req.get_header_names() {
@@ -156,11 +156,11 @@ async fn handle_request(worker: &SxgWorker, req: &Request) -> Result<Response> {
             fallback_url = Url::parse(&url).map_err(Error::new)?;
             (_, cert_origin) = worker.get_fallback_url_and_cert_origin(req.get_url())?;
             sxg_payload = sxg_rs_response_to_fastly_response(payload)?;
-            get_req_header_fields(worker, req, AcceptFilter::AcceptsSxg).await?;
+            get_req_header_fields(worker, req, AcceptLevel::AcceptsSxg).await?;
         }
         None => {
             (fallback_url, cert_origin) = worker.get_fallback_url_and_cert_origin(req.get_url())?;
-            let req_headers = get_req_header_fields(worker, req, AcceptFilter::PrefersSxg).await?;
+            let req_headers = get_req_header_fields(worker, req, AcceptLevel::PrefersSxg).await?;
             sxg_payload = fetch_from_html_server(&fallback_url, req_headers)?;
         }
     };

--- a/http_server/src/main.rs
+++ b/http_server/src/main.rs
@@ -42,7 +42,7 @@ use sxg_rs::{
     acme,
     crypto::CertificateChain,
     fetcher::Fetcher,
-    headers::AcceptFilter,
+    headers::AcceptLevel,
     http::{HttpRequest, HttpResponse, Method},
     http_cache::HttpCache,
     process_html::ProcessHtmlOption,
@@ -360,7 +360,7 @@ async fn handle_impl(client_ip: IpAddr, req: HttpRequest) -> Result<HandleAction
             fallback_url = url;
             let payload: Response<Vec<u8>> = payload.try_into()?;
             sxg_payload = payload.map(Body::from);
-            worker.transform_request_headers(req.headers, AcceptFilter::AcceptsSxg)?;
+            worker.transform_request_headers(req.headers, AcceptLevel::AcceptsSxg)?;
         }
         None => {
             // TODO: Reduce the amount of conversion needed between request/response/header types.
@@ -370,7 +370,7 @@ async fn handle_impl(client_ip: IpAddr, req: HttpRequest) -> Result<HandleAction
                 .0
                 .to_string();
             let req_headers =
-                worker.transform_request_headers(req.headers, AcceptFilter::PrefersSxg)?;
+                worker.transform_request_headers(req.headers, AcceptLevel::PrefersSxg)?;
             let mut request = Request::builder()
                 .method(match req.method {
                     Method::Get => "GET",

--- a/sxg_rs/src/lib.rs
+++ b/sxg_rs/src/lib.rs
@@ -42,7 +42,7 @@ use crate::utils::console_log;
 use anyhow::{anyhow, Error, Result};
 use config::Config;
 use crypto::CertificateChain;
-use headers::{AcceptFilter, Headers};
+use headers::{AcceptLevel, Headers};
 use http_cache::HttpCache;
 use runtime::Runtime;
 use serde::Serialize;
@@ -385,10 +385,11 @@ impl SxgWorker {
     pub fn transform_request_headers(
         &self,
         fields: HeaderFields,
-        accept_filter: AcceptFilter,
+        required_accept_level: AcceptLevel,
     ) -> Result<HeaderFields> {
         let headers = Headers::new(fields, &self.config.strip_request_headers);
-        headers.forward_to_origin_server(accept_filter, &self.config.forward_request_headers)
+        headers
+            .forward_to_origin_server(required_accept_level, &self.config.forward_request_headers)
     }
     /// Checks `fields` as response headers from backend server,
     /// and returns the reqsponse headers to be sent to browser.

--- a/sxg_rs/src/wasm_worker.rs
+++ b/sxg_rs/src/wasm_worker.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::crypto::CertificateChain;
-use crate::headers::AcceptFilter;
+use crate::headers::AcceptLevel;
 use crate::http::HttpResponse;
 use crate::process_html::ProcessHtmlOption;
 use crate::runtime::{js_runtime::JsRuntimeInitParams, Runtime};
@@ -115,18 +115,18 @@ impl WasmWorker {
     #[wasm_bindgen(js_name=createRequestHeaders)]
     pub fn create_request_headers(
         &self,
-        accept_filter: JsValue,
+        required_accept_level: JsValue,
         requestor_headers: JsValue,
     ) -> JsPromise {
         let worker = self.0.clone();
         future_to_promise(async move {
             let fields = serde_wasm_bindgen::from_value(requestor_headers).map_err(to_js_error)?;
-            let accept_filter: AcceptFilter =
-                serde_wasm_bindgen::from_value(accept_filter).map_err(to_js_error)?;
+            let required_accept_level: AcceptLevel =
+                serde_wasm_bindgen::from_value(required_accept_level).map_err(to_js_error)?;
             let fields = worker
                 .read()
                 .await
-                .transform_request_headers(fields, accept_filter)
+                .transform_request_headers(fields, required_accept_level)
                 .map_err(to_js_error)?;
             Ok(serde_wasm_bindgen::to_value(&fields).unwrap())
         })

--- a/typescript_utilities/src/wasmFunctions.ts
+++ b/typescript_utilities/src/wasmFunctions.ts
@@ -28,7 +28,7 @@ declare let wasm_bindgen: any;
 
 type HeaderFields = Array<[string, string]>;
 
-export type AcceptFilter = 'PrefersSxg' | 'AcceptsSxg';
+export type AcceptLevel = 'RejectsSxg' | 'PrefersSxg' | 'AcceptsSxg';
 
 export interface WasmRequest {
   body: number[];
@@ -82,7 +82,7 @@ export interface WasmWorker {
   new (configYaml: string, certificatePem: string | undefined): WasmWorker;
   addAcmeCertificatesFromStorage(runtime: JsRuntimeInitParams): Promise<void>;
   createRequestHeaders(
-    accept_filter: AcceptFilter,
+    required_accept_level: AcceptLevel,
     fields: HeaderFields
   ): Promise<HeaderFields>;
   processHtml(


### PR DESCRIPTION
The old function `validate_accept_header` has been doing two tasks
1. Parse the `q` value of SXG content type
2. Validate that the `q` value meets the requirements.

This PR decouples the two tasks.


* Diff in production code

  ```diff
  - assert!(validate_accept_header(s, required).is_ok());
  + let actual = parse_accept_value(s);
  + assert!(actual >= required);
  ```

* Diff in testing code

  ```diff
  - assert!(validate_accept_header(s, PrefersSxg).is_ok());
  - assert!(validate_accept_header(s, AcceptsSxg).is_ok());
  + assert_eq!(parse_accept_level(s), PrefersSxg);
  ```

  ```diff
  - assert!(validate_accept_header(s, PrefersSxg).is_err());
  - assert!(validate_accept_header(s, AcceptsSxg).is_ok());
  + assert_eq!(parse_accept_level(s), AcceptsSxg);
  ```
