### PR TITLE
Fix errors from Rust Clippy

### DIFF
--- a/sxg_rs/src/header_integrity.rs
+++ b/sxg_rs/src/header_integrity.rs
@@ -183,7 +183,7 @@ pub mod tests {
 
     // For use in other modules' tests.
     pub fn null_integrity_fetcher() -> HeaderIntegrityFetcherImpl<'static, NullCache> {
-        new_fetcher(&NULL_FETCHER, NullCache {}, &*EMPTY_SET)
+        new_fetcher(&NULL_FETCHER, NullCache {}, &EMPTY_SET)
     }
 
     const TEST_URL: &str = "https://signed-exchange-testing.dev/sxgs/image.jpg";

--- a/sxg_rs/src/headers.rs
+++ b/sxg_rs/src/headers.rs
@@ -235,7 +235,7 @@ impl Headers {
             fields.push((k, v));
         }
         let status_code = status_code.to_string();
-        let digest = format!("mi-sha256-03={}", ::base64::encode(&mice_digest));
+        let digest = format!("mi-sha256-03={}", ::base64::encode(mice_digest));
         fields.push((":status", &status_code));
         fields.push(("content-encoding", "mi-sha256-03"));
         fields.push(("digest", &digest));

--- a/sxg_rs/src/mice.rs
+++ b/sxg_rs/src/mice.rs
@@ -34,9 +34,9 @@ pub fn calculate(input: &[u8], record_size: usize) -> (Vec<u8>, Vec<u8>) {
         hasher.update(record);
         if let Some(f) = proofs.front() {
             hasher.update(f);
-            hasher.update(&[1u8]);
+            hasher.update([1u8]);
         } else {
-            hasher.update(&[0u8]);
+            hasher.update([0u8]);
         }
         proofs.push_front(hasher.finalize().to_vec());
     }


### PR DESCRIPTION
Lint Rust code according to the more strict [needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow) and [explicit_auto_deref](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref) rules, which are added by Rust [1.65](https://github.com/rust-lang/rust-clippy/blob/911864df46dc5d4fae2f809126f4e6f090434e8f/CHANGELOG.md#rust-165).

This will fix recent renovate-bot PRs (#413 #424).